### PR TITLE
Added slack integration to notify build status 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-
 notifications:
-  email: true
+  slack: apolloworks:HNnFUCAYcp7fbGsTXWzqCgo2
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
- It will notify build status to #baker-build slack channel. 
- Also, emails to the individual commiter if a build fails or build status changes. 