### PR TITLE
adding kryo serialization mappings for java standard wrapper types

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -49,6 +49,14 @@ akka {
       "io.kagera.akka.actor.PetriNetInstanceProtocol$InstanceState" = kryo
 
       "java.lang.String" = kryo
+      "java.lang.Byte" = kryo
+      "java.lang.Short" = kryo
+      "java.lang.Integer" = kryo
+      "java.lang.Long" = kryo
+      "java.lang.Float" = kryo
+      "java.lang.Double" = kryo
+      "java.lang.Character" = kryo
+      "java.lang.Boolean" = kryo
 
       // map baker internal classes to use kryo serialization
       "com.ing.baker.actor.InternalBakerEvent" = kryo


### PR DESCRIPTION
in case when used as ingredients they do not fallback to JavaSerializer