### PR TITLE
changed the way RetryExhaustedEvents are set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Baker now supports multiple recipes, individual recipes are managed by a 'RecipeHandler'
 - It is possible to add interaction implementations at runtime.
 - Scala/Java DSL alignment: renamed `processEvent -> handleEvent` and `processEventAsync -> handleEventAsync`
+- Exhausted Retry events are now always set with a default name. Its not possible to give the event anymore.
+  Now its just a configuration with a boolean on the RetryWithIncrementalBackoff retry strategy
 
 ## 1.1.17
 - Fix #72: do not join to akka cluster when there are persistence problems. `akka.cluster.seed-nodes` configuration should be renamed to `baker.cluster.seed-nodes` to support this "late cluster join" feature.

--- a/compiler/src/main/scala/com/ing/baker/compiler/package.scala
+++ b/compiler/src/main/scala/com/ing/baker/compiler/package.scala
@@ -3,10 +3,9 @@ package com.ing.baker
 import com.ing.baker.il._
 import com.ing.baker.il.failurestrategy.InteractionFailureStrategy
 import com.ing.baker.il.petrinet._
-import com.ing.baker.types._
 import com.ing.baker.recipe.common
-import com.ing.baker.recipe.common.InteractionFailureStrategy.{FireEventAfterFailure, RetryWithIncrementalBackoff}
 import com.ing.baker.recipe.common.{InteractionDescriptor, ProvidesNothing}
+import com.ing.baker.types._
 
 import scala.concurrent.duration.Duration
 
@@ -24,34 +23,23 @@ package object compiler {
     def toSieveTransition(defaultFailureStrategy: common.InteractionFailureStrategy, allIngredientNames: Set[String]): InteractionTransition[_] =
       interactionTransitionOf(interaction, defaultFailureStrategy, ActionType.SieveAction, allIngredientNames)
 
-    def interactionTransitionOf(
-                                 interactionDescriptor: InteractionDescriptor,
-                                 defaultFailureStrategy: common.InteractionFailureStrategy,
-                                 actionType: ActionType,
-                                 allIngredientNames: Set[String]): InteractionTransition[Any] = {
+    def interactionTransitionOf(interactionDescriptor: InteractionDescriptor,
+                                defaultFailureStrategy: common.InteractionFailureStrategy,
+                                actionType: ActionType,
+                                allIngredientNames: Set[String]): InteractionTransition[Any] = {
 
       //This transforms the event using the eventOutputTransformer to the new event
       //If there is no eventOutputTransformer for the event the original event is returned
       def transformEventType(event: common.Event): common.Event =
-        interactionDescriptor.eventOutputTransformers.get(event)
-        match {
-          case Some(eventOutputTransformer) =>
-            new common.Event {
-              override val name: String = eventOutputTransformer.newEventName
-              override val providedIngredients: Seq[common.Ingredient] = event.providedIngredients.map(i =>
-                new common.Ingredient(eventOutputTransformer.ingredientRenames.getOrElse(i.name, i.name), i.ingredientType))
-            }
-          case _ => event
-        }
-
-      def transformFailureStrategy(recipeStrategy: common.InteractionFailureStrategy): InteractionFailureStrategy = {
-        recipeStrategy match {
-          case common.InteractionFailureStrategy.RetryWithIncrementalBackoff(initialTimeout: Duration, backoffFactor: Double, maximumRetries: Int, maxTimeBetweenRetries: Option[Duration], retryExhaustedEvent: Option[common.Event]) =>
-            il.failurestrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, if(retryExhaustedEvent.isDefined) Some(EventType(retryExhaustedEvent.get.name, Seq.empty)) else None)
-          case common.InteractionFailureStrategy.BlockInteraction() => il.failurestrategy.BlockInteraction
-          case common.InteractionFailureStrategy.FireEventAfterFailure(event) => il.failurestrategy.FireEventAfterFailure(EventType(event.name, Seq.empty))
-          case _ => il.failurestrategy.BlockInteraction
-        }
+      interactionDescriptor.eventOutputTransformers.get(event)
+      match {
+        case Some(eventOutputTransformer) =>
+          new common.Event {
+            override val name: String = eventOutputTransformer.newEventName
+            override val providedIngredients: Seq[common.Ingredient] = event.providedIngredients.map(i =>
+              new common.Ingredient(eventOutputTransformer.ingredientRenames.getOrElse(i.name, i.name), i.ingredientType))
+          }
+        case _ => event
       }
 
       def transformEventOutputTransformer(recipeEventOutputTransformer: common.EventOutputTransformer): EventOutputTransformer =
@@ -67,26 +55,20 @@ package object compiler {
       //Replace ingredient tags with overridden tags
       val inputFields: Seq[(String, Type)] = interactionDescriptor.interaction.inputIngredients
         .map { ingredient =>
-          if(ingredient.name == common.ProcessIdName) il.processIdName -> ingredient.ingredientType
+          if (ingredient.name == common.ProcessIdName) il.processIdName -> ingredient.ingredientType
           else interactionDescriptor.overriddenIngredientNames.getOrElse(ingredient.name, ingredient.name) -> ingredient.ingredientType
         }
-
-      val exhaustedRetryEvent = interactionDescriptor.failureStrategy.flatMap {
-        case RetryWithIncrementalBackoff(_, _, _, _, optionalExhaustedRetryEvent) => optionalExhaustedRetryEvent
-        case FireEventAfterFailure(event) => Some(event)
-        case _ => None
-      }.map(transformEventToCompiledEvent)
 
       val (originalEvents, eventsToFire, providedIngredientEvent): (Seq[EventType], Seq[EventType], Option[EventType]) =
         interactionDescriptor.interaction.output match {
           case common.ProvidesIngredient(outputIngredient) =>
             val ingredientName: String =
-              if(interactionDescriptor.overriddenOutputIngredientName.nonEmpty) interactionDescriptor.overriddenOutputIngredientName.get
+              if (interactionDescriptor.overriddenOutputIngredientName.nonEmpty) interactionDescriptor.overriddenOutputIngredientName.get
               else outputIngredient.name
-            val event = EventType(interactionDescriptor.name + "Successful", Seq(RecordField(ingredientName, outputIngredient.ingredientType)))
+            val event = EventType(interactionDescriptor.name + SuccessEventAppend, Seq(RecordField(ingredientName, outputIngredient.ingredientType)))
             val events = Seq(event)
             (events, events, Some(event))
-          case common.FiresOneOfEvents(events @ _*) =>
+          case common.FiresOneOfEvents(events@_*) =>
             val originalCompiledEvents = events.map(transformEventToCompiledEvent)
             val compiledEvents = events.map(transformEventType).map(transformEventToCompiledEvent)
             (originalCompiledEvents, compiledEvents, None)
@@ -97,13 +79,25 @@ package object compiler {
       //And is of the type Optional or Option
       //Add it to the predefinedIngredients List as empty
       //Add the predefinedIngredients later to overwrite any created empty field with the given predefined value.
-
       val predefinedIngredientsWithOptionalsEmpty: Map[String, Value] =
         inputFields.flatMap {
           case (name, types.OptionType(_)) if !allIngredientNames.contains(name) => Seq(name -> NullValue)
           case _ => Seq.empty
         }.toMap ++ interactionDescriptor.predefinedIngredients
 
+      val (failureStrategy: InteractionFailureStrategy, exhaustedRetryEvent: Option[EventType]) = {
+        interactionDescriptor.failureStrategy.getOrElse[common.InteractionFailureStrategy](defaultFailureStrategy) match {
+          case common.InteractionFailureStrategy.RetryWithIncrementalBackoff(initialTimeout: Duration, backoffFactor: Double, maximumRetries: Int, maxTimeBetweenRetries: Option[Duration], fireRetryExhaustedEvent: Boolean) =>
+            val exhaustedRetryEvent: Option[EventType] = if (fireRetryExhaustedEvent) Some(EventType(interactionDescriptor.name + exhaustedEventAppend, Seq.empty)) else None
+            (il.failurestrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, exhaustedRetryEvent), exhaustedRetryEvent)
+          case common.InteractionFailureStrategy.BlockInteraction() => (
+            il.failurestrategy.BlockInteraction, None)
+          case common.InteractionFailureStrategy.FireEventAfterFailure() =>
+            val exhaustedRetryEvent: EventType = EventType(interactionDescriptor.name + exhaustedEventAppend, Seq.empty)
+            (il.failurestrategy.FireEventAfterFailure(exhaustedRetryEvent), Some(exhaustedRetryEvent))
+          case _ => (il.failurestrategy.BlockInteraction, None)
+        }
+      }
 
       InteractionTransition[Any](
         eventsToFire = eventsToFire ++ exhaustedRetryEvent,
@@ -114,8 +108,8 @@ package object compiler {
         originalInteractionName = interactionDescriptor.interaction.name,
         predefinedParameters = predefinedIngredientsWithOptionalsEmpty,
         maximumInteractionCount = interactionDescriptor.maximumInteractionCount,
-        failureStrategy = transformFailureStrategy(interactionDescriptor.failureStrategy.getOrElse[common.InteractionFailureStrategy](defaultFailureStrategy)),
-        eventOutputTransformers =  interactionDescriptor.eventOutputTransformers.map { case (event, transformer) => eventToCompiledEvent(event) -> transformEventOutputTransformer(transformer) },
+        failureStrategy = failureStrategy,
+        eventOutputTransformers = interactionDescriptor.eventOutputTransformers.map { case (event, transformer) => eventToCompiledEvent(event) -> transformEventOutputTransformer(transformer) },
         actionType = actionType)
     }
   }
@@ -132,6 +126,7 @@ package object compiler {
   implicit class EventTransitionOps(eventTransitions: Seq[EventTransition]) {
     def findEventTransitionsByEvent: EventType ⇒ Option[EventTransition] =
       event => eventTransitions.find(_.event == event)
+
     def findEventTransitionsByEventName: String ⇒ Option[EventTransition] =
       eventName => eventTransitions.find(_.event.name == eventName)
   }

--- a/intermediate-language/src/main/scala/com/ing/baker/il/package.scala
+++ b/intermediate-language/src/main/scala/com/ing/baker/il/package.scala
@@ -12,6 +12,8 @@ import com.ing.baker.il.petrinet.{EventTransition, InteractionTransition, Missin
 package object il {
 
   val processIdName = "$ProcessID$"
+  val SuccessEventAppend = "Successful"
+  val exhaustedEventAppend = "RetryExhausted"
 
 
   implicit class PlaceAdditions(place: Place[_]) {

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/Interaction.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/Interaction.scala
@@ -10,4 +10,6 @@ trait Interaction {
       this.name == other.name && this.inputIngredients == other.inputIngredients && this.output == other.output
     case _ => false
   }
+
+  def retryExhaustedEventName: String = this.name + exhaustedEventAppend
 }

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
@@ -1,7 +1,5 @@
 package com.ing.baker.recipe.common
 
-import com.ing.baker.recipe.common
-
 import scala.annotation.tailrec
 import scala.concurrent.duration.Duration
 
@@ -11,13 +9,13 @@ object InteractionFailureStrategy {
 
   case class BlockInteraction() extends InteractionFailureStrategy
 
-  case class FireEventAfterFailure(event: common.Event) extends InteractionFailureStrategy
+  case class FireEventAfterFailure() extends InteractionFailureStrategy
 
   case class RetryWithIncrementalBackoff(initialTimeout: Duration,
                                          backoffFactor: Double,
                                          maximumRetries: Int,
                                          maxTimeBetweenRetries: Option[Duration] = None,
-                                         retryExhaustedEvent: Option[common.Event] = None) extends InteractionFailureStrategy {
+                                         fireRetryExhaustedEvent: Boolean = false) extends InteractionFailureStrategy {
     require(backoffFactor >= 1.0, "backoff factor must be greater or equal to 1.0")
     require(maximumRetries >= 1, "maximum retries must be greater or equal to 1")
   }
@@ -26,7 +24,7 @@ object InteractionFailureStrategy {
     def apply(initialDelay: Duration,
               deadline: Duration,
               maxTimeBetweenRetries: Option[Duration],
-              exhaustedEvent: Option[common.Event]): RetryWithIncrementalBackoff = {
+              fireRetryExhaustedEvent: Boolean): RetryWithIncrementalBackoff = {
 
       require(deadline > initialDelay, "deadline should be greater then initialDelay")
 
@@ -59,9 +57,8 @@ object InteractionFailureStrategy {
           totalDelay = initialDelay,
           timesCounter = 1),
         maxTimeBetweenRetries,
-        exhaustedEvent)
+        fireRetryExhaustedEvent)
     }
   }
-
 }
 

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/package.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/package.scala
@@ -7,4 +7,7 @@ package object common {
   type IngredientType = Type
 
   val ProcessIdName = "$ProcessId$"
+  val SuccessEventAppend = "Successful"
+  val exhaustedEventAppend = "RetryExhausted"
+
 }

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
@@ -16,7 +16,7 @@ object InteractionFailureStrategy {
       initialDelayDuration,
       deadlineDuration,
       Some(Duration(maxTimeBetweenRetries.toMillis, duration.MILLISECONDS)),
-      None)
+      false)
   }
 
   def RetryWithIncrementalBackoff(initialDelay: java.time.Duration,
@@ -27,37 +27,25 @@ object InteractionFailureStrategy {
       initialDelayDuration,
       deadlineDuration,
       None,
-      None)
+      false)
   }
 
   def RetryWithIncrementalBackoff(initialDelay: java.time.Duration,
                                   deadline: java.time.Duration,
                                   maxTimeBetweenRetries: java.time.Duration,
-                                  exhaustedEvent: Class[_]): RetryWithIncrementalBackoff = {
+                                  fireRetryExhaustedEvent: Boolean): RetryWithIncrementalBackoff = {
     val initialDelayDuration = Duration(initialDelay.toMillis, duration.MILLISECONDS)
     val deadlineDuration = Duration(deadline.toMillis, duration.MILLISECONDS)
     common.InteractionFailureStrategy.RetryWithIncrementalBackoff(
       initialDelayDuration,
       deadlineDuration,
       Some(Duration(maxTimeBetweenRetries.toMillis, duration.MILLISECONDS)),
-      Some(eventClassToCommonEvent(exhaustedEvent, None)))
+      fireRetryExhaustedEvent)
   }
 
-  def FireEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAfterFailure = {
-    FireEventAfterFailure(eventClassToCommonEvent(eventClass, None))
-  }
+  def FireEvent(): common.InteractionFailureStrategy.FireEventAfterFailure =
+    common.InteractionFailureStrategy.FireEventAfterFailure()
 
-  def RetryWithIncrementalBackoff(initialDelay: java.time.Duration,
-                                  deadline: java.time.Duration,
-                                  exhaustedEvent: Class[_]): RetryWithIncrementalBackoff = {
-    val initialDelayDuration = Duration(initialDelay.toMillis, duration.MILLISECONDS)
-    val deadlineDuration = Duration(deadline.toMillis, duration.MILLISECONDS)
-    common.InteractionFailureStrategy.RetryWithIncrementalBackoff(
-      initialDelayDuration,
-      deadlineDuration,
-      None,
-      Some(eventClassToCommonEvent(exhaustedEvent, None)))
-  }
-
-  def BlockInteraction(): BlockInteraction = common.InteractionFailureStrategy.BlockInteraction()
+  def BlockInteraction(): BlockInteraction =
+    common.InteractionFailureStrategy.BlockInteraction()
 }

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/Recipe.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/Recipe.scala
@@ -129,7 +129,6 @@ case class Recipe(
   def withSensoryEventsNoFiringLimit(eventsToAdd: Class[_]*): Recipe =
   copy(sensoryEvents = sensoryEvents ++ eventsToAdd.map(eventClassToCommonEvent(_, None)))
 
-
   /**
     * This set the failure strategy as default for this recipe.
     * If a failure strategy is set for the Interaction itself that is taken.
@@ -139,42 +138,6 @@ case class Recipe(
     */
   def withDefaultFailureStrategy(interactionFailureStrategy: common.InteractionFailureStrategy): Recipe =
     copy(defaultFailureStrategy = interactionFailureStrategy)
-
-  /**
-    * This actives the incremental backup retry strategy for all the interactions if failure occurs
-    *
-    * @param initialDelay the initial delay before the first retry starts
-    * @param deadline     the deadline for how long the retry should run
-    * @return
-    * @deprecated Replaced by withDefaultFailureStrategy
-    */
-  @Deprecated
-  def withDefaultRetryFailureStrategy(initialDelay: java.time.Duration,
-                                      deadline: java.time.Duration,
-                                      maxTimeBetweenRetries: java.time.Duration): Recipe =
-    copy(
-      defaultFailureStrategy =
-        InteractionFailureStrategy.RetryWithIncrementalBackoff(
-          initialDelay,
-          deadline,
-          maxTimeBetweenRetries))
-
-  /**
-    * This actives the incremental backup retry strategy for all the interactions if failure occurs
-    *
-    * @param initialDelay the initial delay before the first retry starts
-    * @param deadline     the deadline for how long the retry should run
-    * @return
-    * @deprecated Replaced by withDefaultFailureStrategy
-    */
-  @Deprecated
-  def withDefaultRetryFailureStrategy(initialDelay: java.time.Duration,
-                                      deadline: java.time.Duration) =
-  copy(
-    defaultFailureStrategy =
-      InteractionFailureStrategy.RetryWithIncrementalBackoff(
-        initialDelay,
-        deadline))
 
   /**
     * Sets the event receive period. This is the period for which processes can receive sensory events.

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/package.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/package.scala
@@ -31,6 +31,13 @@ package object javadsl {
       override val maxFiringLimit: Option[Integer] = firingLimit
     }
 
+  def stringToCommonEvent(eventName: String, firingLimit: Option[Integer]): common.Event =
+    new common.Event {
+      override val name: String = eventName
+      override val providedIngredients: Seq[common.Ingredient] = Seq.empty
+      override val maxFiringLimit: Option[Integer] = firingLimit
+    }
+
   def interactionClassToCommonInteraction(interactionClass: Class[_ <: Interaction]): common.Interaction =
     new common.Interaction {
       override val name: String = interactionClass.getSimpleName

--- a/recipe-dsl/src/main/scala/com/ing/baker/recipe/scaladsl/InteractionDescriptor.scala
+++ b/recipe-dsl/src/main/scala/com/ing/baker/recipe/scaladsl/InteractionDescriptor.scala
@@ -62,8 +62,8 @@ case class InteractionDescriptor private(override val interaction: Interaction,
                                       backoffFactor: Double = 2.0,
                                       maximumRetries: Int = 50,
                                       maxTimeBetweenRetries: Option[Duration] = None,
-                                      exhaustedRetryEvent: Option[Event] = None): InteractionDescriptor =
-    copy(failureStrategy = Some(new RetryWithIncrementalBackoff(initialDelay, backoffFactor, maximumRetries, maxTimeBetweenRetries, exhaustedRetryEvent)))
+                                      fireExhaustedEvent: Boolean = false): InteractionDescriptor =
+    copy(failureStrategy = Some(new RetryWithIncrementalBackoff(initialDelay, backoffFactor, maximumRetries, maxTimeBetweenRetries, fireExhaustedEvent)))
 
   def withEventOutputTransformer(event: Event, newEventName: String, ingredientRenames: Map[String, String]): InteractionDescriptor =
     copy(eventOutputTransformers = eventOutputTransformers + (event -> EventOutputTransformer(newEventName, ingredientRenames)))

--- a/recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/RecipeTest.java
+++ b/recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/RecipeTest.java
@@ -1,5 +1,6 @@
 package com.ing.baker.recipe.javadsl;
 
+import com.ing.baker.recipe.annotations.ProvidesIngredient;
 import com.ing.baker.recipe.javadsl.events.SensoryEventWithIngredient;
 import com.ing.baker.recipe.javadsl.events.SensoryEventWithoutIngredient;
 import com.ing.baker.recipe.javadsl.interactions.FiresTwoEventInteraction;
@@ -148,7 +149,7 @@ public class RecipeTest {
     @Test
     public void shouldUpdateFailureStrategy() {
         Recipe recipe = new Recipe("retryWithIncrementalBackoffFailureStrategyRecipe")
-                .withDefaultRetryFailureStrategy(Duration.ofMillis(100), Duration.ofHours(24));
+                .withDefaultFailureStrategy(InteractionFailureStrategy.RetryWithIncrementalBackoff(Duration.ofMillis(100), Duration.ofHours(24)));
         assertEquals(
                 com.ing.baker.recipe.common.InteractionFailureStrategy.RetryWithIncrementalBackoff.class,
                 recipe.defaultFailureStrategy().getClass());

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/InteractionFailureStrategySpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/InteractionFailureStrategySpec.scala
@@ -16,7 +16,7 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val initialDelay          = 2 seconds
       val backoffFactor: Double = 2.0
 
-      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, maxTimeBetweenRetries = None, None)
+      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, maxTimeBetweenRetries = None, false)
       val expected = RetryWithIncrementalBackoff(initialTimeout = initialDelay,
                                                  backoffFactor,
                                                  maximumRetries = 15)
@@ -30,7 +30,7 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val initialDelay          = 1 seconds
       val backoffFactor: Double = 2.0
 
-      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, None)
+      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, false)
       val expected = RetryWithIncrementalBackoff(initialTimeout = initialDelay,
         backoffFactor,
         maximumRetries = 4)
@@ -45,11 +45,12 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val backoffFactor: Double     = 2.0
       val MaxDurationBetweenRetries = 4 seconds
 
-      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, Some(MaxDurationBetweenRetries), None)
+      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, Some(MaxDurationBetweenRetries), false)
       val expected = RetryWithIncrementalBackoff(initialTimeout = initialDelay,
         backoffFactor,
         maximumRetries = 6,
-        Some(4 seconds))
+        Some(4 seconds),
+        false)
 
       actual shouldEqual expected
     }
@@ -60,7 +61,7 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val initialDelay = 2 seconds
 
       intercept[IllegalArgumentException] {
-        RetryWithIncrementalBackoff(initialDelay, deadline, None, None)
+        RetryWithIncrementalBackoff(initialDelay, deadline, None, false)
       }
     }
 
@@ -70,7 +71,7 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val initialDelay          = 2 seconds
       val backoffFactor: Double = 2.0
 
-      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, None)
+      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, false)
       val expected = RetryWithIncrementalBackoff(initialTimeout = initialDelay,
                                                  backoffFactor,
                                                  maximumRetries = 1)
@@ -84,7 +85,7 @@ class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
       val initialDelay          = 2 seconds
       val backoffFactor: Double = 2.0
 
-      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, None)
+      val actual = RetryWithIncrementalBackoff(initialDelay, deadline, None, false)
       val expected = RetryWithIncrementalBackoff(initialTimeout = initialDelay,
                                                  backoffFactor,
                                                  maximumRetries = 3)

--- a/test-module/src/test/scala/com/ing/baker/compiler/RecipeCompilerSpec.scala
+++ b/test-module/src/test/scala/com/ing/baker/compiler/RecipeCompilerSpec.scala
@@ -36,11 +36,11 @@ class RecipeCompilerSpec extends TestRecipeHelper {
         .withSensoryEvent(initialEvent)
         .withInteractions(interactionOne.withIncrementalBackoffOnFailure(
           initialDelay = 10 milliseconds,
-          exhaustedRetryEvent = Some(exhaustedEvent)))
+          fireExhaustedEvent = true))
 
       val compiledRecipe: CompiledRecipe = RecipeCompiler.compileRecipe(recipe)
 
-      compiledRecipe.allEvents.map(_.name) should contain(exhaustedEvent.name)
+      compiledRecipe.allEvents.map(_.name) should contain(interactionOne.retryExhaustedEventName)
     }
 
     "give a List of missing ingredients if an interaction has an ingredient that is not provided by any other event or interaction" in {


### PR DESCRIPTION
Now you configure a boolean if you want one and a default one is created.
Its not possible to set your own custom events anymore.
This makes it possible to use this as the defaultRetryStrategy on the recipe.
In the old solution they would get the same event that would only fire is all interactions retry exhaust. 