### PR TITLE
Event name list

### DIFF
--- a/runtime/src/main/protobuf/common.proto
+++ b/runtime/src/main/protobuf/common.proto
@@ -131,6 +131,7 @@ message RuntimeEvent {
 message ProcessState {
     optional string processId = 1;
     repeated Ingredient ingredients = 2;
+    repeated string eventNames = 3;
 }
 // END DATA
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
@@ -176,7 +176,7 @@ class ProcessIndex(cleanupInterval: FiniteDuration = 1 minute,
 
             getCompiledRecipe(recipeId) match {
               case Some(compiledRecipe) =>
-                val initialize = Initialize(ProcessInstanceProtocol.marshal(compiledRecipe.initialMarking), ProcessState(processId, Map.empty))
+                val initialize = Initialize(ProcessInstanceProtocol.marshal(compiledRecipe.initialMarking), ProcessState(processId, Map.empty, List.empty))
                 createProcessActor(processId, compiledRecipe).forward(initialize)
                 val actorMetadata = ActorMetadata(recipeId, processId, created, Active)
                 index += processId -> actorMetadata

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
@@ -12,7 +12,7 @@ import com.ing.baker.runtime.actor.InternalBakerMessage
 import com.ing.baker.runtime.actor.process_instance.ProcessInstance._
 import com.ing.baker.runtime.actor.process_instance.ProcessInstanceLogger._
 import com.ing.baker.runtime.actor.process_instance.ProcessInstanceProtocol._
-import com.ing.baker.runtime.actor.serialization.{Encryption, ObjectSerializer}
+import com.ing.baker.runtime.actor.serialization.Encryption
 import fs2.Strategy
 
 import scala.concurrent.duration._
@@ -44,13 +44,12 @@ object ProcessInstance {
 /**
   * This actor is responsible for maintaining the state of a single petri net instance.
   */
-class ProcessInstance[P[_], T[_, _], S, E](
-                                             processType: String,
-                                             processTopology: PetriNet[P[_], T[_, _]],
-                                             settings: Settings,
-                                             runtime: PetriNetRuntime[P, T, S, E],
-                                             override implicit val placeIdentifier: Identifiable[P[_]],
-                                             override implicit val transitionIdentifier: Identifiable[T[_, _]]) extends ProcessInstanceRecovery[P, T, S, E](processTopology, settings.encryption, runtime.eventSourceFn) {
+class ProcessInstance[P[_], T[_, _], S, E](processType: String,
+                                            processTopology: PetriNet[P[_], T[_, _]],
+                                            settings: Settings,
+                                            runtime: PetriNetRuntime[P, T, S, E],
+                                            override implicit val placeIdentifier: Identifiable[P[_]],
+                                            override implicit val transitionIdentifier: Identifiable[T[_, _]]) extends ProcessInstanceRecovery[P, T, S, E](processTopology, settings.encryption, runtime.eventSourceFn) {
 
 
   val log: DiagnosticLoggingAdapter = Logging.getLogger(this)

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapter.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapter.scala
@@ -65,7 +65,7 @@ trait ProtoEventAdapter {
 
       case e: core.ProcessState =>
         val ingredients = writeIngredients(e.ingredients.toSeq)
-        protobuf.ProcessState(Some(e.processId), ingredients)
+        protobuf.ProcessState(Some(e.processId), ingredients, e.eventNames)
 
       case il.EventDescriptor(name, ingredients) =>
 
@@ -312,8 +312,8 @@ trait ProtoEventAdapter {
       case protobuf.RuntimeEvent(Some(name), ingredients) =>
         core.RuntimeEvent(name, readIngredients(ingredients))
 
-      case protobuf.ProcessState(Some(id), ingredients) =>
-        core.ProcessState(id, readIngredients(ingredients).toMap)
+      case protobuf.ProcessState(Some(id), ingredients, events) =>
+        core.ProcessState(id, readIngredients(ingredients).toMap, events.toList)
 
       case protobuf.PetriNet(protoNodes, protoEdges) =>
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -257,6 +257,12 @@ class Baker()(implicit val actorSystem: ActorSystem) {
   }
 
   /**
+    * Synchronously returns all event names that occurred for a process.
+    */
+  def eventNames(processId: String, timeout: FiniteDuration = defaultInquireTimeout): List[String] =
+    getProcessState(processId, timeout).eventNames
+
+  /**
     * Returns a Source of baker events for a process.
     *
     * @param processId The process identifier.
@@ -291,7 +297,7 @@ class Baker()(implicit val actorSystem: ActorSystem) {
     */
   @throws[NoSuchProcessException]("When no process exists for the given id")
   @throws[TimeoutException]("When the request does not receive a reply within the given deadline")
-  private def getProcessState(processId: String, timeout: FiniteDuration = defaultInquireTimeout): ProcessState =
+  def getProcessState(processId: String, timeout: FiniteDuration = defaultInquireTimeout): ProcessState =
   Await.result(getProcessStateAsync(processId), timeout)
 
   /**

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/ProcessState.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/ProcessState.scala
@@ -2,4 +2,4 @@ package com.ing.baker.runtime.core
 
 import com.ing.baker.types.Value
 
-case class ProcessState(processId: String, ingredients: Map[String, Value]) extends Serializable
+case class ProcessState(processId: String, ingredients: Map[String, Value], eventNames: List[String]) extends Serializable

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/interations/MethodInteractionImplementation.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/interations/MethodInteractionImplementation.scala
@@ -76,7 +76,7 @@ object MethodInteractionImplementation {
 
     // when the interaction does not fire an event, Void or Unit is a valid output type
     if (interaction.eventsToFire.isEmpty && output == null)
-      RuntimeEvent(interaction.interactionName, Seq.empty)
+      null
 
     // if the interaction directly produces an ingredient
     else if (interaction.providedIngredientEvent.isDefined) {

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -573,7 +573,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getProcessState(processId: UUID): ProcessState =
-  baker.getProcessState(processId.toString)
+    baker.getProcessState(processId.toString)
 
   /**
     * Returns the state of a process instance. This includes the ingredients and names of the events.
@@ -586,7 +586,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getProcessState(processId: UUID, timeout: java.time.Duration): ProcessState =
-  baker.getProcessState(processId.toString, timeout.toScala)
+    baker.getProcessState(processId.toString, timeout.toScala)
 
   /**
     * Returns the event names of a process instance
@@ -598,7 +598,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getEventNames(processId: String): java.util.List[String] =
-    baker.getProcessState(processId).eventNames.asJava
+    baker.eventNames(processId).asJava
 
   /**
     * Returns the event names of a process instance
@@ -611,7 +611,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getEventNames(processId: String, timeout: java.time.Duration): java.util.List[String] =
-    baker.getProcessState(processId, timeout.toScala).eventNames.asJava
+    baker.eventNames(processId, timeout.toScala).asJava
 
   /**
     * Returns the event names of a process instance
@@ -623,7 +623,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getEventNames(processId: UUID): java.util.List[String] =
-  baker.getProcessState(processId.toString).eventNames.asJava
+    baker.eventNames(processId.toString).asJava
 
   /**
     * Returns the event names of a process instance
@@ -636,7 +636,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[ProcessDeletedException]("If the process is already deleted")
   @throws[NoSuchProcessException]("If the process is not found")
   def getEventNames(processId: UUID, timeout: java.time.Duration): java.util.List[String] =
-  baker.getProcessState(processId.toString, timeout.toScala).eventNames.asJava
+    baker.eventNames(processId.toString, timeout.toScala).asJava
 
   /**
     * Returns the visual state of the recipe in dot format
@@ -673,5 +673,5 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   @throws[NoSuchProcessException]("If the process is not found")
   @throws[TimeoutException]("When the process does not respond within the default deadline")
   def getVisualState(processId: UUID): String =
-  getVisualState(processId.toString)
+    getVisualState(processId.toString)
 }

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -412,6 +412,106 @@ class JBaker(actorSystem: ActorSystem, implementations: java.lang.Iterable[AnyRe
     baker.getVisualState(processId, timeout.toScala)
 
   /**
+    * Returns the state of a process instance. This includes the ingredients and names of the events.
+    *
+    * @param processId The process identifier
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getProcessState(processId: String): ProcessState =
+    baker.getProcessState(processId)
+
+  /**
+    * Returns the state of a process instance. This includes the ingredients and names of the events.
+    *
+    * @param processId The process identifier
+    * @param timeout   The maximum time to wait
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getProcessState(processId: String, timeout: java.time.Duration): ProcessState =
+    baker.getProcessState(processId, timeout.toScala)
+
+  /**
+    * Returns the state of a process instance. This includes the ingredients and names of the events.
+    *
+    * @param processId The process identifier
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getProcessState(processId: UUID): ProcessState =
+  baker.getProcessState(processId.toString)
+
+  /**
+    * Returns the state of a process instance. This includes the ingredients and names of the events.
+    *
+    * @param processId The process identifier
+    * @param timeout   The maximum time to wait
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getProcessState(processId: UUID, timeout: java.time.Duration): ProcessState =
+  baker.getProcessState(processId.toString, timeout.toScala)
+
+  /**
+    * Returns the event names of a process instance
+    *
+    * @param processId The process identifier
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getEventNames(processId: String): java.util.List[String] =
+    baker.getProcessState(processId).eventNames.asJava
+
+  /**
+    * Returns the event names of a process instance
+    *
+    * @param processId The process identifier
+    * @param timeout   The maximum time to wait
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getEventNames(processId: String, timeout: java.time.Duration): java.util.List[String] =
+    baker.getProcessState(processId, timeout.toScala).eventNames.asJava
+
+  /**
+    * Returns the event names of a process instance
+    *
+    * @param processId The process identifier
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getEventNames(processId: UUID): java.util.List[String] =
+  baker.getProcessState(processId.toString).eventNames.asJava
+
+  /**
+    * Returns the event names of a process instance
+    *
+    * @param processId The process identifier
+    * @param timeout   The maximum time to wait
+    * @return The state of the process instance
+    */
+  @throws[TimeoutException]("When the process does not respond within the default deadline")
+  @throws[ProcessDeletedException]("If the process is already deleted")
+  @throws[NoSuchProcessException]("If the process is not found")
+  def getEventNames(processId: UUID, timeout: java.time.Duration): java.util.List[String] =
+  baker.getProcessState(processId.toString, timeout.toScala).eventNames.asJava
+
+  /**
     * Returns the visual state of the recipe in dot format
     *
     * @param processId The process identifier

--- a/runtime/src/main/scala/com/ing/baker/runtime/petrinet/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/petrinet/RecipeRuntime.scala
@@ -11,7 +11,7 @@ object RecipeRuntime {
   def eventSourceFn: Transition[_, _] => (ProcessState => RuntimeEvent => ProcessState) =
     _ => state => {
       case null => state
-      case RuntimeEvent(_, providedIngredients) => state.copy(ingredients = state.ingredients ++ providedIngredients)
+      case RuntimeEvent(name, providedIngredients) => state.copy(ingredients = state.ingredients ++ providedIngredients, eventNames = state.eventNames :+ name)
     }
 }
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexSpec.scala
@@ -77,7 +77,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
     "create the PetriNetInstance actor when Initialize message is received" in {
       val processId = UUID.randomUUID().toString
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       val petriNetActorProbe = TestProbe()
 
@@ -90,7 +90,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
     "not create the PetriNetInstance actor if already created" in {
       val processId = UUID.randomUUID().toString
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       val petriNetActorProbe = TestProbe()
       val actorIndex = createActorIndex(petriNetActorProbe.ref, recipeManager)
@@ -123,7 +123,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
       recipeManagerProbe.reply(AllRecipes(Map[String, CompiledRecipe](recipeId ->
         CompiledRecipe("name", ScalaGraphPetriNet(Graph.empty), Marking.empty, Seq.empty, Option.empty, Some(recipeRetentionPeriod)))))
 
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
       processProbe.expectMsg(initializeMsg)
 
       processProbe.expectMsg(Stop(delete = true))
@@ -139,7 +139,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
       val processId = UUID.randomUUID().toString
 
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       val petrinetMock: RecipePetriNet = mock[RecipePetriNet]
       val eventType = EventDescriptor("Event", Seq.empty)
@@ -193,7 +193,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
       val processId = UUID.randomUUID().toString
 
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       actorIndex ! CreateProcess(recipeId, processId)
       recipeManagerProbe.expectMsg(GetAllRecipes)
@@ -220,7 +220,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
       val processId = UUID.randomUUID().toString
 
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       val petrinetMock: RecipePetriNet = mock[RecipePetriNet]
       val eventType = EventDescriptor("Event", Seq(IngredientDescriptor("ingredientName", PrimitiveType(classOf[String]))))
@@ -252,7 +252,7 @@ class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIn
 
       val processId = UUID.randomUUID().toString
 
-      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty))
+      val initializeMsg = Initialize(Map.empty, ProcessState(processId, Map.empty, List.empty))
 
       val petrinetMock: RecipePetriNet = mock[RecipePetriNet]
       val eventType = EventDescriptor("Event", Seq.empty)

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializerSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializerSpec.scala
@@ -26,8 +26,9 @@ class BakerProtobufSerializerSpec extends TestKit(ActorSystem("BakerProtobufSeri
 
   val processStateGen: Gen[ProcessState] = for {
     name <- Gen.alphaNumStr
-    ingredient <- Gen.mapOf(ingredientTupleGen)
-  } yield ProcessState(name, ingredient)
+    ingredients <- Gen.mapOf(ingredientTupleGen)
+    eventNames <- Gen.listOf(Gen.alphaNumStr)
+  } yield ProcessState(name, ingredients, eventNames)
 
   val bakerObjectGen: Gen[Object] = Gen.oneOf(runtimeEventGen, processStateGen)
 

--- a/test-module/src/test/java/com/ing/baker/JBakerTest.java
+++ b/test-module/src/test/java/com/ing/baker/JBakerTest.java
@@ -16,6 +16,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import scala.Option;
+import scala.collection.immutable.List;
+import scala.collection.immutable.List$;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.util.Collections;
@@ -110,6 +112,8 @@ public class JBakerTest {
         FiniteDuration testTimeoutScala = new FiniteDuration(testTimeout.toMillis(), TimeUnit.MILLISECONDS);
         EventListener testListener = (processId, event) -> { };
 
+        when(mockBaker.eventNames(any(String.class), any(FiniteDuration.class))).thenReturn(List$.MODULE$.empty());
+
         // -- bake
 
         jBaker.bake(testRecipeId, processStringId);
@@ -133,6 +137,20 @@ public class JBakerTest {
 
         jBaker.getEvents(processUUID);
         verify(mockBaker).events(eq(processUUID.toString()), any(FiniteDuration.class));
+
+        // -- get event names
+
+        jBaker.getEventNames(processStringId);
+        verify(mockBaker).eventNames(eq(processStringId), any(FiniteDuration.class));
+
+        jBaker.getEventNames(processUUID);
+        verify(mockBaker).eventNames(eq(processUUID.toString()), any(FiniteDuration.class));
+
+        jBaker.getEventNames(processStringId, testTimeout);
+        verify(mockBaker).eventNames(eq(processStringId), eq(testTimeoutScala));
+
+        jBaker.getEventNames(processUUID, testTimeout);
+        verify(mockBaker).eventNames(eq(processUUID.toString()), eq(testTimeoutScala));
 
         // -- get recipe
 

--- a/test-module/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/test-module/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -721,6 +721,29 @@ class BakerExecutionSpec extends TestRecipeHelper {
       )
     }
 
+    "be able to return all occurred event names" in {
+
+      val (baker, recipeId) = setupBakerWithRecipe("CheckEventNamesRecipe")
+
+      val processId = UUID.randomUUID().toString
+      baker.bake(recipeId, processId)
+
+      //Handle two event
+      baker.processEvent(processId, InitialEvent(initialIngredientValue))
+      baker.processEvent(processId, SecondEvent())
+
+      //Check if both the new event and the events occurred in the past are in the eventsList
+      baker.eventNames(processId) should contain only(
+        "InitialEvent",
+        "EventFromInteractionTwo",
+        "SecondEvent",
+        "InteractionOneSuccessful",
+        "SieveInteractionSuccessful",
+        "InteractionThreeSuccessful",
+        "InteractionFourSuccessful"
+      )
+    }
+
     //Only works if persistence actors are used (think cassandra)
     "recover the state of a process from a persistence store" in {
       val system1 = ActorSystem("persistenceTest1", levelDbConfig("persistenceTest1", 3002))


### PR DESCRIPTION
Allows to use GetEventNameList to get the events directly from the ProcessInstance instead of using Akka query .
This is more optimized if you are only interested in the names of the events instead of their contents.