### PR TITLE
Fix broken ExampleSpec link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An introductory presentation of Baker: [Baker talk @ Amsterdam.Scala meetup](htt
 
 A talk about Baker at the Scale By the Bay 2017 conference: [Declare, verify and execute microservices-based process flows](https://www.youtube.com/watch?v=0bWQwUmeXHU).
 
-An example web-shop recipe you can find at: [ExamplesSpec](https://github.com/ing-bank/baker/blob/master/test-module/src/test/scala/com/ing/baker/ExamplesSpec.scala) 
+An example web-shop recipe you can find at: [ExamplesSpec](runtime/src/test/scala/com/ing/baker/runtime/ExamplesSpec.scala) 
 
 WebShop Recipe:
 ```scala


### PR DESCRIPTION
The link to `ExampleSpec` from the main project's README was broken