### PR TITLE
Make event input works as OR instead of AND

### DIFF
--- a/compiler/src/main/scala/com/ing/baker/compiler/RecipeCompiler.scala
+++ b/compiler/src/main/scala/com/ing/baker/compiler/RecipeCompiler.scala
@@ -49,7 +49,7 @@ object RecipeCompiler {
 
     interaction.requiredOneOfEvents.toSeq.zipWithIndex.map { case (orGroup: Set[String], index: Int) =>
       // only one `Place` for all the OR events
-      val eventPreconditionPlace = createPlace(label = s"${interaction.name}-or-$index" , placeType = EventOrPreconditionPlace)
+      val eventPreconditionPlace = createPlace(label = s"${interaction.name}-or-$index", placeType = EventOrPreconditionPlace)
 
       orGroup.toSeq.map { eventName =>
         buildEventPreconditionArcs(eventName,
@@ -60,11 +60,10 @@ object RecipeCompiler {
     }.unzipFlatten
   }
 
-  private def buildEventPreconditionArcs(
-                                          eventName: String,
-                                          preconditionPlace: Place[_],
-                                          preconditionTransition: String => Option[Transition],
-                                          interactionTransition: Transition): (Seq[Arc], Seq[String]) = {
+  private def buildEventPreconditionArcs(eventName: String,
+                                         preconditionPlace: Place[_],
+                                         preconditionTransition: String => Option[Transition],
+                                         interactionTransition: Transition): (Seq[Arc], Seq[String]) = {
 
     val eventTransition = preconditionTransition(eventName)
 
@@ -87,10 +86,15 @@ object RecipeCompiler {
                                         findInternalEventByEvent: EventDescriptor => Option[Transition]): Seq[Arc] = {
     val resultPlace = createPlace(label = interaction.label, placeType = InteractionEventOutputPlace)
     if (interaction.eventsToFire.nonEmpty) {
-      val eventArcs = events.map { event =>
-        val internalEventTransition = findInternalEventByEvent(event).get
-
-        arc(resultPlace, internalEventTransition, 1, Some(event.name))
+      val eventArcs = events.flatMap { event =>
+        val eventCombinerPlace: Place[_] = createPlace(label = s"IntermediatePlace:${event.name}", placeType = IntermediatePlace)
+        //Create a new intermediate transition
+        val interactionToEventTransition: IntermediateTransition = IntermediateTransition(s"${interaction.interactionName}:${event.name}")
+        //link the new transition to the event input place
+        val intermediateTransitionToEventCombinerPlace: Arc = arc(interactionToEventTransition, eventCombinerPlace, 1)
+        //link the interaction output place to the interactionTransition
+        val interactionOutputPlaceToInteramediateTransition: Arc = arc(resultPlace, interactionToEventTransition, 1, Some(event.name))
+        Seq(intermediateTransitionToEventCombinerPlace, interactionOutputPlaceToInteramediateTransition)
       }
       arc(interaction, resultPlace, 1) +: eventArcs
     }
@@ -189,7 +193,9 @@ object RecipeCompiler {
     val allInteractionTransitions: Seq[InteractionTransition] = sieveTransitions ++ interactionTransitions
 
     // events provided from outside
-    val sensoryEventTransitions: Seq[EventTransition] = recipe.sensoryEvents.map { event => EventTransition(eventToCompiledEvent(event), isSensoryEvent = true, event.maxFiringLimit) }.toSeq
+    val sensoryEventTransitions: Seq[EventTransition] = recipe.sensoryEvents.map {
+      event => EventTransition(eventToCompiledEvent(event), isSensoryEvent = true, event.maxFiringLimit)
+    }.toSeq
 
     // events provided by other transitions / actions
     val interactionEventTransitions: Seq[EventTransition] = allInteractionTransitions.flatMap { t =>
@@ -217,8 +223,15 @@ object RecipeCompiler {
       }
     )
 
-    def findEventTransitionByEventName (eventName: String) = allEventTransitions.find(_.event.name == eventName)
+    def findEventTransitionByEventName(eventName: String) = allEventTransitions.find(_.event.name == eventName)
+
     def findInteractionByLabel(label: String) = allInteractionTransitions.find(_.label == label)
+
+
+    //Create events combiner input places
+    val eventInputArcs: Seq[Arc] = interactionEventTransitions.flatMap(
+      (event: EventTransition) => Seq(arc(createPlace(s"IntermediatePlace:${event.label}", IntermediatePlace), event, 1))
+    )
 
     // This generates precondition arcs for Required Events (AND).
     val (eventPreconditionArcs, preconditionANDErrors) = actionDescriptors.map { t =>
@@ -272,6 +285,7 @@ object RecipeCompiler {
           e => interactionEventTransitions.find(_.event.name == e.name)))
 
     val arcs = (interactionArcs
+      ++ eventInputArcs
       ++ eventPreconditionArcs
       ++ eventOrPreconditionArcs
       ++ eventLimiterArcs

--- a/compiler/src/main/scala/com/ing/baker/compiler/RecipeCompiler.scala
+++ b/compiler/src/main/scala/com/ing/baker/compiler/RecipeCompiler.scala
@@ -87,7 +87,7 @@ object RecipeCompiler {
     val resultPlace = createPlace(label = interaction.label, placeType = InteractionEventOutputPlace)
     if (interaction.eventsToFire.nonEmpty) {
       val eventArcs = events.flatMap { event =>
-        val eventCombinerPlace: Place[_] = createPlace(label = s"IntermediatePlace:${event.name}", placeType = IntermediatePlace)
+        val eventCombinerPlace: Place[_] = createPlace(label = event.name, placeType = IntermediatePlace)
         //Create a new intermediate transition
         val interactionToEventTransition: IntermediateTransition = IntermediateTransition(s"${interaction.interactionName}:${event.name}")
         //link the new transition to the event input place
@@ -230,7 +230,7 @@ object RecipeCompiler {
 
     //Create events combiner input places
     val eventInputArcs: Seq[Arc] = interactionEventTransitions.flatMap(
-      (event: EventTransition) => Seq(arc(createPlace(s"IntermediatePlace:${event.label}", IntermediatePlace), event, 1))
+      (event: EventTransition) => Seq(arc(createPlace(event.label, IntermediatePlace), event, 1))
     )
 
     // This generates precondition arcs for Required Events (AND).

--- a/intermediate-language/src/main/scala/com/ing/baker/il/dot/PetriNetDot.scala
+++ b/intermediate-language/src/main/scala/com/ing/baker/il/dot/PetriNetDot.scala
@@ -10,8 +10,8 @@ import scalax.collection.io.dot.implicits._
 object PetriNetDot {
 
   def labelFn[P, T]: Either[P, T] ⇒ String = node ⇒ node match {
-    case Left(p)  ⇒ s"p$p"
-    case Right(t) ⇒ s"t$t"
+    case Left(p)  ⇒ s"$p"
+    case Right(t) ⇒ s"$t"
   }
 
   def petriNetTheme[P, T]: GraphTheme[Either[P, T], WLDiEdge] = new GraphTheme[Either[P, T], WLDiEdge] {

--- a/intermediate-language/src/main/scala/com/ing/baker/il/petrinet/Place.scala
+++ b/intermediate-language/src/main/scala/com/ing/baker/il/petrinet/Place.scala
@@ -13,8 +13,8 @@ object Place {
   case object InteractionEventOutputPlace extends PlaceType
   case class  FiringLimiterPlace(maxLimit: Int) extends PlaceType
   case object EventPreconditionPlace extends PlaceType
-  case object EventOrPreconditionPlace extends PlaceType {override def labelPrepend: String = "EventOrPreconditionPlace:"}
-  case object IntermediatePlace extends PlaceType
+  case object EventOrPreconditionPlace extends PlaceType { override def labelPrepend: String = "EventOrPreconditionPlace:" }
+  case object IntermediatePlace extends PlaceType  { override def labelPrepend: String = "IntermediatePlace:" }
   case object EmptyEventIngredientPlace extends PlaceType
   case object MultiTransitionPlace extends PlaceType
 

--- a/petrinet-api/src/main/scala/com/ing/baker/petrinet/api/package.scala
+++ b/petrinet-api/src/main/scala/com/ing/baker/petrinet/api/package.scala
@@ -32,12 +32,9 @@ package object api extends MultiSetOps with MarkingOps {
 
   implicit def extractId[T](e: T)(implicit identifiable: Identifiable[T]) = identifiable(e).value
 
-  implicit class IdentifiableOps[T: Identifiable](seq: Iterable[T]) {
+  implicit class IdentifiableOps[T : Identifiable](seq: Iterable[T]) {
     def findById(id: Long): Option[T] = seq.find(e ⇒ implicitly[Identifiable[T]].apply(e).value == id)
-
-    def getById(id: Long, name: String = "element"): T = findById(id).getOrElse {
-      throw new IllegalStateException(s"No $name found with id: $id")
-    }
+    def getById(id: Long, name: String = "element"): T = findById(id).getOrElse { throw new IllegalStateException(s"No $name found with id: $id") }
   }
 
   implicit class OptionOps(check: Boolean) {
@@ -60,46 +57,35 @@ package object api extends MultiSetOps with MarkingOps {
   type BiPartiteGraph[P, T, E[X] <: EdgeLikeIn[X]] = Graph[Either[P, T], E]
 
   implicit def placeToNode[P, T](p: P): Either[P, T] = Left(p)
-
   implicit def transitionToNode[P, T](t: T): Either[P, T] = Right(t)
 
   implicit class PetriNetGraphNodeOps[P, T](val node: BiPartiteGraph[P, T, WLDiEdge]#NodeT) {
 
     def asPlace: P = node.value match {
       case Left(p) ⇒ p
-      case _ ⇒ throw new IllegalStateException(s"node $node is not a place!")
+      case _       ⇒ throw new IllegalStateException(s"node $node is not a place!")
     }
 
     def asTransition: T = node.value match {
       case Right(t) ⇒ t
-      case _ ⇒ throw new IllegalStateException(s"node $node is not a transition!")
+      case _        ⇒ throw new IllegalStateException(s"node $node is not a transition!")
     }
 
-    def incomingPlaces: Set[P] = node.incoming
-      .filter(_.source.isPlace)
-      .map(_.source.asPlace)
+    def incomingNodes: Set[Either[P, T]] = node.incoming.map(_.source.value)
+    def incomingPlaces: Set[P] = incomingNodes.collect { case Left(place) => place }
+    def incomingTransitions: Set[T] = incomingNodes.collect { case Right(transition) => transition }
 
-    def incomingTransitions: Set[T] = node.incoming
-      .filter(_.source.isTransition)
-      .map(_.source.asTransition)
-
-    def outgoingPlaces: Set[P] = node.outgoing
-      .filter(_.target.isPlace)
-      .map(_.target.asPlace)
-
-    def outgoingTransitions: Set[T] = node.outgoing
-      .filter(_.target.isTransition)
-      .map(_.target.asTransition)
+    def outgoingNodes: Set[Either[P, T]] = node.outgoing.map(_.target.value)
+    def outgoingPlaces: Set[P] = outgoingNodes.collect { case Left(place) => place }
+    def outgoingTransitions: Set[T] = outgoingNodes.collect { case Right(transition) => transition }
 
     def isPlace: Boolean = node.value.isLeft
-
     def isTransition: Boolean = node.value.isRight
   }
 
   implicit class PetriNetGraphOps[P, T](val graph: BiPartiteGraph[P, T, WLDiEdge]) {
 
     def inMarking(t: T): MultiSet[P] = graph.get(t).incoming.map(e ⇒ e.source.asPlace -> e.weight.toInt).toMap
-
     def outMarking(t: T): MultiSet[P] = graph.get(t).outgoing.map(e ⇒ e.target.asPlace -> e.weight.toInt).toMap
 
     def findPTEdge(from: P, to: T): Option[WLDiEdge[Either[P, T]]] =
@@ -108,6 +94,5 @@ package object api extends MultiSetOps with MarkingOps {
     def findTPEdge(from: T, to: P): Option[WLDiEdge[Either[P, T]]] =
       graph.get(Right(from)).outgoing.find(_.target.value == Left(to)).map(_.toOuter)
   }
-
 }
 

--- a/petrinet-api/src/main/scala/com/ing/baker/petrinet/api/package.scala
+++ b/petrinet-api/src/main/scala/com/ing/baker/petrinet/api/package.scala
@@ -32,9 +32,12 @@ package object api extends MultiSetOps with MarkingOps {
 
   implicit def extractId[T](e: T)(implicit identifiable: Identifiable[T]) = identifiable(e).value
 
-  implicit class IdentifiableOps[T : Identifiable](seq: Iterable[T]) {
+  implicit class IdentifiableOps[T: Identifiable](seq: Iterable[T]) {
     def findById(id: Long): Option[T] = seq.find(e ⇒ implicitly[Identifiable[T]].apply(e).value == id)
-    def getById(id: Long, name: String = "element"): T = findById(id).getOrElse { throw new IllegalStateException(s"No $name found with id: $id") }
+
+    def getById(id: Long, name: String = "element"): T = findById(id).getOrElse {
+      throw new IllegalStateException(s"No $name found with id: $id")
+    }
   }
 
   implicit class OptionOps(check: Boolean) {
@@ -57,33 +60,46 @@ package object api extends MultiSetOps with MarkingOps {
   type BiPartiteGraph[P, T, E[X] <: EdgeLikeIn[X]] = Graph[Either[P, T], E]
 
   implicit def placeToNode[P, T](p: P): Either[P, T] = Left(p)
+
   implicit def transitionToNode[P, T](t: T): Either[P, T] = Right(t)
 
   implicit class PetriNetGraphNodeOps[P, T](val node: BiPartiteGraph[P, T, WLDiEdge]#NodeT) {
 
     def asPlace: P = node.value match {
       case Left(p) ⇒ p
-      case _       ⇒ throw new IllegalStateException(s"node $node is not a place!")
+      case _ ⇒ throw new IllegalStateException(s"node $node is not a place!")
     }
 
     def asTransition: T = node.value match {
       case Right(t) ⇒ t
-      case _        ⇒ throw new IllegalStateException(s"node $node is not a transition!")
+      case _ ⇒ throw new IllegalStateException(s"node $node is not a transition!")
     }
 
-    def incomingPlaces: Set[P] = node.incoming.map(_.source.asPlace)
-    def incomingTransitions: Set[T] = node.incoming.map(_.source.asTransition)
+    def incomingPlaces: Set[P] = node.incoming
+      .filter(_.source.isPlace)
+      .map(_.source.asPlace)
 
-    def outgoingPlaces: Set[P] = node.outgoing.map(_.target.asPlace)
-    def outgoingTransitions: Set[T] = node.outgoing.map(_.target.asTransition)
+    def incomingTransitions: Set[T] = node.incoming
+      .filter(_.source.isTransition)
+      .map(_.source.asTransition)
+
+    def outgoingPlaces: Set[P] = node.outgoing
+      .filter(_.target.isPlace)
+      .map(_.target.asPlace)
+
+    def outgoingTransitions: Set[T] = node.outgoing
+      .filter(_.target.isTransition)
+      .map(_.target.asTransition)
 
     def isPlace: Boolean = node.value.isLeft
+
     def isTransition: Boolean = node.value.isRight
   }
 
   implicit class PetriNetGraphOps[P, T](val graph: BiPartiteGraph[P, T, WLDiEdge]) {
 
     def inMarking(t: T): MultiSet[P] = graph.get(t).incoming.map(e ⇒ e.source.asPlace -> e.weight.toInt).toMap
+
     def outMarking(t: T): MultiSet[P] = graph.get(t).outgoing.map(e ⇒ e.target.asPlace -> e.weight.toInt).toMap
 
     def findPTEdge(from: P, to: T): Option[WLDiEdge[Either[P, T]]] =
@@ -92,5 +108,6 @@ package object api extends MultiSetOps with MarkingOps {
     def findTPEdge(from: T, to: P): Option[WLDiEdge[Either[P, T]]] =
       graph.get(Right(from)).outgoing.find(_.target.value == Left(to)).map(_.toOuter)
   }
+
 }
 

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/TestRecipe.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/TestRecipe.scala
@@ -181,6 +181,18 @@ object TestRecipe {
     def apply(interactionSevenIngredient1: String, interactionSevenIngredient2: String): Unit
   }
 
+  val fireTwoEventsInteraction =
+    Interaction(
+      name = "fireTwoEventsInteraction",
+      inputIngredients = Seq(initialIngredient),
+      output = FiresOneOfEvents(eventFromInteractionTwo, event1FromInteractionSeven))
+
+  trait fireTwoEventsInteraction {
+    val name: String = "fireTwoEventsInteraction"
+
+    def apply(initialIngredient: String): Event1FromInteractionSeven
+  }
+
   val providesNothingInteraction =
     Interaction(
       name = "ProvidesNothingInteraction",

--- a/runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
+++ b/runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import com.ing.baker.recipe.TestRecipe._
+import com.ing.baker.recipe.TestRecipe.{fireTwoEventsInteraction, _}
 import com.ing.baker.compiler.RecipeCompiler
 import com.ing.baker.recipe.{CaseClassIngredient, common}
 import com.ing.baker.runtime.core.Baker
@@ -73,6 +73,7 @@ trait BakerRuntimeTestBase
   protected val testInteractionFourMock: InteractionFour = mock[InteractionFour]
   protected val testInteractionFiveMock: InteractionFive = mock[InteractionFive]
   protected val testInteractionSixMock: InteractionSix = mock[InteractionSix]
+  protected val testFireTwoEventsInteractionMock: fireTwoEventsInteraction = mock[fireTwoEventsInteraction]
   protected val testComplexIngredientInteractionMock: ComplexIngredientInteraction = mock[ComplexIngredientInteraction]
   protected val testCaseClassIngredientInteractionMock: CaseClassIngredientInteraction = mock[CaseClassIngredientInteraction]
   protected val testCaseClassIngredientInteraction2Mock: CaseClassIngredientInteraction2 = mock[CaseClassIngredientInteraction2]
@@ -89,6 +90,7 @@ trait BakerRuntimeTestBase
       testInteractionFourMock,
       testInteractionFiveMock,
       testInteractionSixMock,
+      testFireTwoEventsInteractionMock,
       testComplexIngredientInteractionMock,
       testCaseClassIngredientInteractionMock,
       testCaseClassIngredientInteraction2Mock,

--- a/runtime/src/test/scala/com/ing/baker/il/RecipeVisualizerSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/il/RecipeVisualizerSpec.scala
@@ -1,14 +1,13 @@
-package com.ing.baker.runtime.visualisation
+package com.ing.baker.il
 
 import com.ing.baker.compiler.RecipeCompiler
-import com.ing.baker.il.{CompiledRecipe, RecipeVisualizer}
 import com.ing.baker.recipe.TestRecipe._
 import com.ing.baker.recipe.scaladsl.{Recipe, _}
 import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.language.postfixOps
 
-class RecipeVisualizationSpec extends WordSpecLike with Matchers {
+class RecipeVisualizerSpec extends WordSpecLike with Matchers {
 
   "The Recipe visualisation module" should {
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -139,10 +139,10 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
       val (baker, recipeId) = setupBakerWithRecipe(recipe, mockImplementations)
 
 //      val compiledRecipe = RecipeCompiler.compileRecipe(recipe)
-      println("recipe visualisation:")
-      println(baker.getCompiledRecipe(recipeId).getRecipeVisualization)
-      println("petrinet visualisation:")
-      println(baker.getCompiledRecipe(recipeId).getPetriNetVisualization)
+//      println("recipe visualisation:")
+//      println(baker.getCompiledRecipe(recipeId).getRecipeVisualization)
+//      println("petrinet visualisation:")
+//      println(baker.getCompiledRecipe(recipeId).getPetriNetVisualization)
 
       when(testInteractionTwoMock.apply(anyString()))
         .thenReturn(EventFromInteractionTwo("ingredient2"))

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -10,7 +10,7 @@ import com.ing.baker.recipe.TestRecipe._
 import com.ing.baker._
 import com.ing.baker.compiler.RecipeCompiler
 import com.ing.baker.recipe.CaseClassIngredient
-import com.ing.baker.recipe.common.InteractionFailureStrategy
+import com.ing.baker.recipe.common.{FiresOneOfEvents, InteractionFailureStrategy}
 import com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAfterFailure
 import com.ing.baker.recipe.scaladsl.{Recipe, _}
 import com.ing.baker.types.PrimitiveValue
@@ -123,6 +123,44 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
           "initialIngredient" -> initialIngredientValue,
           "interactionOneOriginalIngredient" -> interactionOneIngredientValue)
     }
+
+    "Fire an event twice if two Interactions fire it both" in {
+
+      val recipe =
+        Recipe("IngredientProvidedRecipe")
+          .withInteractions(
+            interactionTwo
+              .withOverriddenIngredientName("initialIngredientOld", "initialIngredient"),
+            fireTwoEventsInteraction,
+            interactionOne
+              .withRequiredEvents(eventFromInteractionTwo))
+          .withSensoryEvents(initialEvent)
+
+      val (baker, recipeId) = setupBakerWithRecipe(recipe, mockImplementations)
+
+//      val compiledRecipe = RecipeCompiler.compileRecipe(recipe)
+//      println("recipe visualisation:")
+      println(baker.getCompiledRecipe(recipeId).getRecipeVisualization)
+//      println("petrinet visualisation:")
+//      println(baker.getCompiledRecipe(recipeId).getPetriNetVisualization)
+
+      when(testInteractionTwoMock.apply(anyString()))
+        .thenReturn(EventFromInteractionTwo("ingredient2"))
+      when(testFireTwoEventsInteractionMock.apply(anyString()))
+        .thenReturn(Event1FromInteractionSeven("ingredient3"))
+
+      val processId = UUID.randomUUID().toString
+
+      baker.bake(recipeId, processId)
+      baker.processEvent(processId, InitialEvent(initialIngredientValue))
+
+      verify(testInteractionTwoMock).apply(initialIngredientValue)
+      verify(testFireTwoEventsInteractionMock).apply(initialIngredientValue)
+      verify(testInteractionOneMock).apply(processId, initialIngredientValue)
+      baker.getProcessState(processId).eventNames should contain
+        ("InitialEvent", "Event1FromInteractionSeven", "EventFromInteractionTwo", "InteractionOneSuccessful")
+    }
+
 
     "only allow a sensory event be fired once if the max firing limit is set one" in {
       val recipe =

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -139,10 +139,10 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
       val (baker, recipeId) = setupBakerWithRecipe(recipe, mockImplementations)
 
 //      val compiledRecipe = RecipeCompiler.compileRecipe(recipe)
-//      println("recipe visualisation:")
+      println("recipe visualisation:")
       println(baker.getCompiledRecipe(recipeId).getRecipeVisualization)
-//      println("petrinet visualisation:")
-//      println(baker.getCompiledRecipe(recipeId).getPetriNetVisualization)
+      println("petrinet visualisation:")
+      println(baker.getCompiledRecipe(recipeId).getPetriNetVisualization)
 
       when(testInteractionTwoMock.apply(anyString()))
         .thenReturn(EventFromInteractionTwo("ingredient2"))


### PR DESCRIPTION
Changed the way input places work for events.
Now one shared input place is created for each event.
Interactions that fire events now are linked via a new Intermediate transition to the event.
This way the incoming lines from interactions towards an Event work like an OR instead of an AND.

Also rewrote the compactNode of the recipe visualiser so that it can compact transitions correctly and not only places.

This closes #42