### PR TITLE
Do not visualize multi facilitator transitions

### DIFF
--- a/intermediate-language/src/main/scala/com/ing/baker/il/RecipeVisualizer.scala
+++ b/intermediate-language/src/main/scala/com/ing/baker/il/RecipeVisualizer.scala
@@ -204,7 +204,7 @@ object RecipeVisualizer {
 
     // specifies which transitions to compact (remove)
     val transitionsToCompact = (node: RecipePetriNetGraph#NodeT) => node.value match {
-      case Right(transition: Transition) => transition.isInstanceOf[IntermediateTransition]
+      case Right(transition: Transition) => transition.isInstanceOf[IntermediateTransition] || transition.isMultiFacilitatorTransition
       case _ => false
     }
 


### PR DESCRIPTION
This removes the intermediate small circle node for intermediate transitions the recipe graph