### PR TITLE
Custom failure resolution for failed interactions, fixes #109

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ native/
 .ensime
 /**/*.pdf
 /**/.DS_Store
+site/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Developers declare the orchestration logic in a recipe.
 A recipe is made out of **interactions** (system calls), **ingredients** (data) and **events**.
 A visual representation (shown below) of the recipe allows product owners, architects and developers to talk the same language.
 
+The official documentation website of Baker: [Official Documentation](https://ing-bank.github.io/baker/).
+
 An introductory presentation of Baker: [Baker talk @ Amsterdam.Scala meetup](https://www.slideshare.net/BekirOguz/designing-process-flows-with-baker).
 
 A talk about Baker at the Scale By the Bay 2017 conference: [Declare, verify and execute microservices-based process flows](https://www.youtube.com/watch?v=0bWQwUmeXHU).

--- a/docs.md
+++ b/docs.md
@@ -56,12 +56,16 @@ Afterwards you will need to update the ing-bank.github.io repository.
 
 The `gh-pages` branch from baker is a sub repository located in the `/baker` directory.
 
-Pull (or clone) from https://github.com/ing-bank/ing-bank.github.io
+If not cloned before, clone from https://github.com/ing-bank/ing-bank.github.io with the following command:
+``` bash
+git clone --recurse-submodules https://github.com/ing-bank/ing-bank.github.io.git
+```
 
 Then execute the following commands inside the repository directory.
 
 ``` bash
-git pull --recurse-submodules
+cd ing-bank.github.io/
+git submodule update --recursive --remote
 git commit -am 'update baker docs'
-git push
+git push origin master
 ```

--- a/docs/documentation/process-execution.md
+++ b/docs/documentation/process-execution.md
@@ -211,7 +211,7 @@ if (events.exists(_.name == "InvoiceWasSend"))
 ```java tab="Java"
 // Get all events that have happend for this process instance
 EventList events = baker.getEvents(processId);
-if (events.hasEventOccured(InvoiceWasSend.class))
+if (events.hasEventOccurred(InvoiceWasSend.class))
     // Yes the invoice was send!
 ```
 

--- a/docs/documentation/process-execution.md
+++ b/docs/documentation/process-execution.md
@@ -128,6 +128,43 @@ In response to recieving a sensory event baker returns a status code indicating 
 | `ReceivePeriodExpired` | The receive period for the process instance has passed |
 | `FiringLimitMet` | The [firing limit](recipe-dsl.md#firing-limit) for the event was met |
 
+## Incident resolving
+
+It is possible that during execution a process instance becomes *blocked*.
+
+This can happen either because it is [directly blocked](recipe-dsl.md#block-interaction) by a exception or that the retry strategy was exhuasted.
+
+At this point it is possible to resolve the blocked interaction in 2 ways.
+
+### 1. Force retry
+
+For example, the retry strategy for *"SendInvoice"* was exhausted after a few hours or retrying.
+
+However, we checked and know the *"invoice"* service is up again and want to continue to process for our customer.
+
+``` scala tab="Scala"
+baker.retryInteraction(processId, "SendInvoice")
+```
+
+``` java tab="Java"
+baker.retryInteraction(processId, "SendInvoice");
+```
+
+### 2. Specify the interaction output
+
+For example, the *"ShipGoods"* backend service is not idempotent and failed with an exception. It is not retried but *blocked*.
+
+However, we checked and know the goods were actually shipped and want to continue the process for our customer.
+
+``` scala tab="Scala"
+baker.resolveInteraction(processId, "ShipGoods", GoodsShipped("some goods"))
+```
+
+``` java tab="Java"
+baker.resolveInteraction(processId, "ShipGoods", new GoodsSchipped("some goods"));
+```
+
+
 ## State inquiry
 
 During runtime it is often useful to *inquire* on the state of a process instance.

--- a/docs/documentation/recipe-dsl.md
+++ b/docs/documentation/recipe-dsl.md
@@ -159,6 +159,16 @@ In this case the interaction may fire if *either* `EventA` OR `EventB` has occur
 
 When an interaction throws an exception there are a number of mitigation strategies:
 
+#### Block interaction
+
+This option is for non idempotent interactions that cannot be retried.
+
+When an exception is thrown from the interaction the interaction is *blocked*.
+
+This means that the interaction cannot execute again automatically.
+
+It requires [manual intervening]() to continue the process from then on.
+
 #### Fire event
 
 This option is analagous to a `try { } catch { }` in code. When an exception is raised from the interaction you specify an

--- a/intermediate-language/src/main/scala/com/ing/baker/petrinet/api/MultiSetOps.scala
+++ b/intermediate-language/src/main/scala/com/ing/baker/petrinet/api/MultiSetOps.scala
@@ -20,6 +20,12 @@ trait MultiSetOps {
         }
       }
 
+    /**
+      * This checks that the given (other) multiset is a sub set of this one.
+      *
+      * @param other
+      * @return
+      */
     def isSubSet(other: MultiSet[T]): Boolean =
       !other.exists {
         case (element, count) ⇒ mset.get(element) match {
@@ -30,8 +36,6 @@ trait MultiSetOps {
       }
 
     def multisetSize: Int = mset.values.sum
-
-    def multiplicities(map: MultiSet[T]): Map[T, Int] = map
 
     def setMultiplicity(map: Map[T, Int])(element: T, m: Int) = map + (element -> m)
 

--- a/runtime/src/main/protobuf/process_index.proto
+++ b/runtime/src/main/protobuf/process_index.proto
@@ -74,6 +74,11 @@ message ResolveBlockedInteraction {
     optional RuntimeEvent event = 3;
 }
 
+message StopRetryingInteraction {
+    optional string processId = 1;
+    optional string interactionName = 2;
+}
+
 message ProcessEventResponse {
     optional string processId = 1;
     optional SerializedData sourceRef = 2;

--- a/runtime/src/main/protobuf/process_index.proto
+++ b/runtime/src/main/protobuf/process_index.proto
@@ -63,6 +63,17 @@ message ProcessEvent {
     optional int64 timeout = 5;
 }
 
+message RetryBlockedInteraction {
+    optional string processId = 1;
+    optional string interactionName = 2;
+}
+
+message ResolveBlockedInteraction {
+    optional string processId = 1;
+    optional string interactionName = 2;
+    optional RuntimeEvent event = 3;
+}
+
 message ProcessEventResponse {
     optional string processId = 1;
     optional SerializedData sourceRef = 2;

--- a/runtime/src/main/protobuf/process_instance.proto
+++ b/runtime/src/main/protobuf/process_instance.proto
@@ -133,20 +133,6 @@ message TransitionNotEnabled {
     optional string reason = 2;
 }
 
-message RetryBlockedJob {
-    optional int64 jobId = 1;
-}
-
-message ResolveBlockedJob {
-    optional int64 jobId = 1;
-    repeated MarkingData produced = 2;
-    optional SerializedData output = 3;
-}
-
-message InvalidCommand {
-    optional string reason = 1;
-}
-
 message TransitionFiredMessage {
     optional int64 jobId = 1;
     optional int64 transitionId = 2;
@@ -180,4 +166,13 @@ message FailureStrategyMessage {
     optional int64 retryDelay = 2;
     repeated MarkingData marking = 3;
     optional SerializedData output = 4;
+}
+
+message OverrideExceptionStrategy {
+    optional int64 jobId = 1;
+    optional FailureStrategyMessage failureStrategy = 2;
+}
+
+message InvalidCommand {
+    optional string reason = 1;
 }

--- a/runtime/src/main/protobuf/process_instance.proto
+++ b/runtime/src/main/protobuf/process_instance.proto
@@ -133,6 +133,20 @@ message TransitionNotEnabled {
     optional string reason = 2;
 }
 
+message RetryBlockedJob {
+    optional int64 jobId = 1;
+}
+
+message ResolveBlockedJob {
+    optional int64 jobId = 1;
+    repeated MarkingData produced = 2;
+    optional SerializedData output = 3;
+}
+
+message InvalidCommand {
+    optional string reason = 1;
+}
+
 message TransitionFiredMessage {
     optional int64 jobId = 1;
     optional int64 transitionId = 2;

--- a/runtime/src/main/protobuf/process_instance.proto
+++ b/runtime/src/main/protobuf/process_instance.proto
@@ -40,7 +40,7 @@ message TransitionFired {
 message FailureStrategy {
     enum StrategyType {
         BLOCK_TRANSITION = 0;
-//        FATAL = 1;
+//        FATAL = 1; deprecated option, do not re-use this identifier!
         RETRY = 2;
     }
 
@@ -157,7 +157,7 @@ message TransitionFailedMessage {
 message FailureStrategyMessage {
     enum StrategyTypeMessage {
         BLOCK_TRANSITION = 0;
-//        FATAL = 1;
+//        FATAL = 1; deprecated option, do not re-use this identifier!
         RETRY = 2;
         CONTINUE = 3;
     }

--- a/runtime/src/main/protobuf/process_instance.proto
+++ b/runtime/src/main/protobuf/process_instance.proto
@@ -40,7 +40,7 @@ message TransitionFired {
 message FailureStrategy {
     enum StrategyType {
         BLOCK_TRANSITION = 0;
-        FATAL = 1;
+//        FATAL = 1;
         RETRY = 2;
     }
 
@@ -157,7 +157,7 @@ message TransitionFailedMessage {
 message FailureStrategyMessage {
     enum StrategyTypeMessage {
         BLOCK_TRANSITION = 0;
-        FATAL = 1;
+//        FATAL = 1;
         RETRY = 2;
         CONTINUE = 3;
     }

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
@@ -159,7 +159,7 @@ class ProcessIndex(processIdleTimeout: Option[FiniteDuration],
     }
   }
 
-  def getInteractionJob(processId: String, interactionName: String, processActor: ActorRef) = {
+  def getInteractionJob(processId: String, interactionName: String, processActor: ActorRef): OptionT[Future, (InteractionTransition, Id)] = {
     // we find which job correlates with the interaction
     for {
       recipe     <- OptionT.fromOption(getCompiledRecipe(index(processId).recipeId))

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
@@ -286,7 +286,7 @@ class ProcessIndex(processIdleTimeout: Option[FiniteDuration],
         } yield jobId
 
         jobIdOptionT.value.onComplete {
-          case Success(Some(jobId)) => actorRef.tell(RetryBlockedTransition(jobId), originalSender)
+          case Success(Some(jobId)) => actorRef.tell(RetryBlockedJob(jobId), originalSender)
           case Success(_)           => originalSender ! akka.actor.Status.Failure(new IllegalArgumentException("Interaction is not blocked"))
           case Failure(exception)   => originalSender ! akka.actor.Status.Failure(exception)
         }
@@ -315,7 +315,7 @@ class ProcessIndex(processIdleTimeout: Option[FiniteDuration],
               case None        =>
                 val petriNet = getCompiledRecipe(index(processId).recipeId).get.petriNet
                 val producedMarking = RecipeRuntime.createProducedMarking(petriNet.outMarking(interaction), Some(event))
-                actorRef.tell(ResolveBlockedTransition(jobId, producedMarking.marshall, event), originalSender)
+                actorRef.tell(ResolveBlockedJob(jobId, producedMarking.marshall, event), originalSender)
               case Some(error) =>
                 log.warning("Invalid event given: " + error)
                 originalSender ! InvalidEvent(processId, error)

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexProtocol.scala
@@ -32,6 +32,8 @@ object ProcessIndexProtocol {
 
   case class ResolveBlockedInteraction(override val processId: String, interactionName: String, output: RuntimeEvent) extends ProcessIndexMessage
 
+  case class StopRetryingInteraction(override val processId: String, interactionName: String) extends ProcessIndexMessage
+
   // --- RESPONSES
 
   /**

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndexProtocol.scala
@@ -28,6 +28,9 @@ object ProcessIndexProtocol {
 
   case class GetCompiledRecipe(override val processId: String) extends ProcessIndexMessage
 
+  case class RetryBlockedInteraction(override val processId: String, interactionName: String) extends ProcessIndexMessage
+
+  case class ResolveBlockedInteraction(override val processId: String, interactionName: String, output: RuntimeEvent) extends ProcessIndexMessage
 
   // --- RESPONSES
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
@@ -253,7 +253,7 @@ class ProcessInstance[P : Identifiable, T : Identifiable, S, E](
           sender() ! NoSuchJob(jobId)
       }
 
-    case ResolveFailure(jobId, produce, output) =>
+    case ResolveBlockedTransition(jobId, produce, output) =>
 
       instance.jobs.get(jobId) match {
         // resolving is only allowed if the interaction was blocked previously

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
@@ -256,7 +256,7 @@ class ProcessInstance[P : Identifiable, T : Identifiable, S, E](
     case ResolveFailure(jobId, produce, output) =>
 
       instance.jobs.get(jobId) match {
-        // retry is only allowed if the interaction was blocked previously
+        // resolving is only allowed if the interaction was blocked previously
         case Some(internal.Job(_, correlationId, _, transition, consumed, _, Some(internal.ExceptionState(_, _, _, internal.ExceptionStrategy.BlockTransition)))) =>
 
           val producedMarking: Marking[P] = produce.unmarshall[P](petriNet.places)
@@ -267,7 +267,7 @@ class ProcessInstance[P : Identifiable, T : Identifiable, S, E](
 
             // to resolve the failure a successful TransitionFiredEvent is created
             val event = TransitionFiredEvent(jobId, transition.getId, correlationId, System.currentTimeMillis(), System.currentTimeMillis(), consumed.marshall, produce, output)
-            // here we process the TransitionFiredEvent event synchronously
+            // and processed synchronously
             running(instance, scheduledRetries).apply(event)
           }
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstance.scala
@@ -82,7 +82,6 @@ class ProcessInstance[P : Identifiable, T : Identifiable, S, E](
     protocol.ExceptionState(exceptionState.failureCount, exceptionState.failureReason, fromExecutionExceptionStrategy(exceptionState.failureStrategy))
 
   private implicit def fromExecutionExceptionStrategy(strategy: internal.ExceptionStrategy): protocol.ExceptionStrategy = strategy match {
-    case internal.ExceptionStrategy.Fatal                     => protocol.ExceptionStrategy.Fatal
     case internal.ExceptionStrategy.BlockTransition           => protocol.ExceptionStrategy.BlockTransition
     case internal.ExceptionStrategy.RetryWithDelay(delay)     => protocol.ExceptionStrategy.RetryWithDelay(delay)
     case internal.ExceptionStrategy.Continue(marking, output) => protocol.ExceptionStrategy.Continue(marking.asInstanceOf[Marking[P]].marshall, output)

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
@@ -51,7 +51,7 @@ object ProcessInstanceProtocol {
   /**
     * Command to resolve a blocked transition.
     */
-  case class ResolveFailure(jobId: Long, marking: Marking[Id], output: Any) extends Command
+  case class ResolveBlockedTransition(jobId: Long, marking: Marking[Id], output: Any) extends Command
 
   /**
    * A common trait for all responses coming from a petri net instance.
@@ -162,7 +162,6 @@ object ProcessInstanceProtocol {
 
     case class Continue(marking: Marking[Id], output: Any) extends ExceptionStrategy
   }
-
 
   /**
    * Response containing the state of the `Job`.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
@@ -152,8 +152,6 @@ object ProcessInstanceProtocol {
 
   object ExceptionStrategy {
 
-    case object Fatal extends ExceptionStrategy
-
     case object BlockTransition extends ExceptionStrategy
 
     case class RetryWithDelay(delay: Long) extends ExceptionStrategy {

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
@@ -46,12 +46,12 @@ object ProcessInstanceProtocol {
   /**
     * Command to retry a blocked transition that is blocked.
     */
-  case class RetryBlockedTransition(jobId: Long) extends Command
+  case class RetryBlockedJob(jobId: Long) extends Command
 
   /**
     * Command to resolve a blocked transition.
     */
-  case class ResolveBlockedTransition(jobId: Long, marking: Marking[Id], output: Any) extends Command
+  case class ResolveBlockedJob(jobId: Long, marking: Marking[Id], output: Any) extends Command
 
   /**
    * A common trait for all responses coming from a petri net instance.
@@ -131,14 +131,11 @@ object ProcessInstanceProtocol {
     reason: String) extends TransitionResponse
 
   /**
-    * Response when trying to resolve or re-try a job that is not blocked.
+    * General response indicating that the send command was invalid.
+    *
+    * @param reason The invalid reason.
     */
-  case class TransitionIsNotBlocked(jobId: Long) extends Response
-
-  /**
-    * Response when trying to resolve or re-try a non existing job
-    */
-  case class NoSuchJob(jobId: Long) extends Response
+  case class InvalidCommand(reason: String) extends Response
 
   /**
    * The exception state of a transition.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
@@ -44,6 +44,16 @@ object ProcessInstanceProtocol {
     correlationId: Option[String] = None) extends Command
 
   /**
+    * Command to retry a blocked transition that is blocked.
+    */
+  case class RetryBlockedTransition(jobId: Long) extends Command
+
+  /**
+    * Command to resolve a blocked transition.
+    */
+  case class ResolveFailure(jobId: Long, marking: Marking[Id], output: Any) extends Command
+
+  /**
    * A common trait for all responses coming from a petri net instance.
    */
   sealed trait Response extends BakerProtoMessage
@@ -119,6 +129,16 @@ object ProcessInstanceProtocol {
   case class TransitionNotEnabled(
     override val transitionId: Id,
     reason: String) extends TransitionResponse
+
+  /**
+    * Response when trying to resolve or re-try a job that is not blocked.
+    */
+  case class TransitionIsNotBlocked(jobId: Long) extends Response
+
+  /**
+    * Response when trying to resolve or re-try a non existing job
+    */
+  case class NoSuchJob(jobId: Long) extends Response
 
   /**
    * The exception state of a transition.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceProtocol.scala
@@ -44,14 +44,12 @@ object ProcessInstanceProtocol {
     correlationId: Option[String] = None) extends Command
 
   /**
-    * Command to retry a blocked transition that is blocked.
+    * Overrides the chosen exception strategy of a job (running transition)
+    *
+    * @param jobId The id of the job.
+    * @param failureStrategy The new failure strategy
     */
-  case class RetryBlockedJob(jobId: Long) extends Command
-
-  /**
-    * Command to resolve a blocked transition.
-    */
-  case class ResolveBlockedJob(jobId: Long, marking: Marking[Id], output: Any) extends Command
+  case class OverrideExceptionStrategy(jobId: Long, failureStrategy: ExceptionStrategy) extends Command
 
   /**
    * A common trait for all responses coming from a petri net instance.
@@ -152,7 +150,7 @@ object ProcessInstanceProtocol {
     case object BlockTransition extends ExceptionStrategy
 
     case class RetryWithDelay(delay: Long) extends ExceptionStrategy {
-      require(delay > 0, "Delay must be greater then zero")
+      require(delay >= 0, "Delay must be greater then zero")
     }
 
     case class Continue(marking: Marking[Id], output: Any) extends ExceptionStrategy

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSerialization.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSerialization.scala
@@ -4,11 +4,11 @@ import java.security.MessageDigest
 
 import com.ing.baker.petrinet.api._
 import com.ing.baker.runtime.actor.process_instance.ProcessInstanceEventSourcing._
-import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, Fatal, RetryWithDelay}
-import com.ing.baker.runtime.actor.process_instance.internal.Instance
-import com.ing.baker.runtime.actor.process_instance.protobuf._
-import com.ing.baker.runtime.actor.process_instance.protobuf.FailureStrategy.StrategyType
 import com.ing.baker.runtime.actor.process_instance.ProcessInstanceSerialization._
+import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, RetryWithDelay}
+import com.ing.baker.runtime.actor.process_instance.internal.Instance
+import com.ing.baker.runtime.actor.process_instance.protobuf.FailureStrategy.StrategyType
+import com.ing.baker.runtime.actor.process_instance.protobuf._
 import com.ing.baker.runtime.actor.protobuf.{ProducedToken, SerializedData}
 import com.ing.baker.runtime.actor.serialization.ProtoEventAdapter
 
@@ -139,7 +139,6 @@ class ProcessInstanceSerialization[P : Identifiable, T : Identifiable, S, E](ser
       val consumed = deserializeConsumedMarking(instance, e.consumed)
       val failureStrategy = e.failureStrategy.getOrElse(missingFieldException("time_failed")) match {
         case FailureStrategy(Some(StrategyType.BLOCK_TRANSITION), _) ⇒ BlockTransition
-        case FailureStrategy(Some(StrategyType.FATAL), _) ⇒ Fatal
         case FailureStrategy(Some(StrategyType.RETRY), Some(delay)) ⇒ RetryWithDelay(delay)
         case other@_ ⇒ throw new IllegalStateException(s"Invalid failure strategy: $other")
       }
@@ -151,7 +150,6 @@ class ProcessInstanceSerialization[P : Identifiable, T : Identifiable, S, E](ser
 
     val strategy = e.exceptionStrategy match {
       case BlockTransition ⇒ FailureStrategy(Some(StrategyType.BLOCK_TRANSITION))
-      case Fatal ⇒ FailureStrategy(Some(StrategyType.FATAL))
       case RetryWithDelay(delay) ⇒ FailureStrategy(Some(StrategyType.RETRY), Some(delay))
       case _ => throw new IllegalArgumentException("Unsupported exception strategy")
     }

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/ExceptionStrategy.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/ExceptionStrategy.scala
@@ -18,7 +18,7 @@ object ExceptionStrategy {
    * Retries firing the transition after some delay.
    */
   case class RetryWithDelay(delay: Long) extends ExceptionStrategy {
-    require(delay > 0, "Delay must be greater then zero")
+    require(delay >= 0, "Delay must be greater then zero")
   }
 
   case class Continue[P, O](marking: Marking[P], output: O) extends ExceptionStrategy {}

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/ExceptionStrategy.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/ExceptionStrategy.scala
@@ -5,11 +5,6 @@ import com.ing.baker.petrinet.api.Marking
 object ExceptionStrategy {
 
   /**
-   * Indicates a non recoverable exception that should prevent any execution of this and other transitions.
-   */
-  case object Fatal extends ExceptionStrategy
-
-  /**
    * Indicates that this transition should not be retried but other transitions in the petri net still can.
    */
   case object BlockTransition extends ExceptionStrategy
@@ -21,7 +16,7 @@ object ExceptionStrategy {
     require(delay >= 0, "Delay must be greater then zero")
   }
 
-  case class Continue[P, O](marking: Marking[P], output: O) extends ExceptionStrategy {}
+  case class Continue[P, O](marking: Marking[P], output: O) extends ExceptionStrategy
 }
 
 sealed trait ExceptionStrategy

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Instance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Instance.scala
@@ -37,12 +37,10 @@ case class Instance[P, T, S](
   /**
     * Checks whether a transition is blocked by a previous failure.
     */
-  def isBlockedReason(transition: T): Option[String] = jobs.values.map {
+  def isBlocked(transition: T): Boolean = jobs.values.collectFirst {
     case Job(_, _, _, `transition`, _, _, Some(ExceptionState(_, _, reason, _))) ⇒
-
-      Some(s"Transition '$transition' is blocked because it failed previously with: $reason")
-    case _ ⇒ None
-  }.find(_.isDefined).flatten
+      s"Transition '$transition' is blocked because it failed previously with: $reason"
+  }.isDefined
 
   def hasReceivedCorrelationId(correlationId: String): Boolean =
     receivedCorrelationIds.contains(correlationId) || jobs.values.exists(_.correlationId == Some(correlationId))

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Instance.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Instance.scala
@@ -34,11 +34,13 @@ case class Instance[P, T, S](
     */
   def activeJobs: Iterable[Job[P, T, S]] = jobs.values.filter(_.isActive)
 
+  /**
+    * Checks whether a transition is blocked by a previous failure.
+    */
   def isBlockedReason(transition: T): Option[String] = jobs.values.map {
     case Job(_, _, _, `transition`, _, _, Some(ExceptionState(_, _, reason, _))) ⇒
+
       Some(s"Transition '$transition' is blocked because it failed previously with: $reason")
-    case Job(_, _, _, t, _, _, Some(ExceptionState(_, _, reason, ExceptionStrategy.Fatal))) ⇒
-      Some(s"Transition '$t' caused a Fatal exception")
     case _ ⇒ None
   }.find(_.isDefined).flatten
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Job.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Job.scala
@@ -1,7 +1,7 @@
 package com.ing.baker.runtime.actor.process_instance.internal
 
 import com.ing.baker.petrinet.api.Marking
-import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, RetryWithDelay}
+import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.RetryWithDelay
 
 /**
  * A Job encapsulates all the parameters that make a firing transition in a petri net.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Job.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_instance/internal/Job.scala
@@ -1,7 +1,7 @@
 package com.ing.baker.runtime.actor.process_instance.internal
 
 import com.ing.baker.petrinet.api.Marking
-import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.RetryWithDelay
+import com.ing.baker.runtime.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, RetryWithDelay}
 
 /**
  * A Job encapsulates all the parameters that make a firing transition in a petri net.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
@@ -53,6 +53,7 @@ class BakerProtobufSerializer(system: ExtendedActorSystem) extends SerializerWit
     Entry("ProcessIndexProtocol.ProcessEvent", classOf[ProcessIndexProtocol.ProcessEvent], actor.process_index.protobuf.ProcessEvent),
     Entry("ProcessIndexProtocol.RetryBlockedInteraction", classOf[ProcessIndexProtocol.RetryBlockedInteraction], actor.process_index.protobuf.RetryBlockedInteraction),
     Entry("ProcessIndexProtocol.ResolveBlockedInteraction", classOf[ProcessIndexProtocol.ResolveBlockedInteraction], actor.process_index.protobuf.ResolveBlockedInteraction),
+    Entry("ProcessIndexProtocol.StopRetryingInteraction", classOf[ProcessIndexProtocol.StopRetryingInteraction], actor.process_index.protobuf.StopRetryingInteraction),
 
     Entry("ProcessIndexProtocol.ProcessEventResponse", classOf[ProcessIndexProtocol.ProcessEventResponse], actor.process_index.protobuf.ProcessEventResponse),
     Entry("ProcessIndexProtocol.GetProcessState", classOf[ProcessIndexProtocol.GetProcessState], actor.process_index.protobuf.GetProcessState),

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
@@ -54,7 +54,6 @@ class BakerProtobufSerializer(system: ExtendedActorSystem) extends SerializerWit
     Entry("ProcessIndexProtocol.RetryBlockedInteraction", classOf[ProcessIndexProtocol.RetryBlockedInteraction], actor.process_index.protobuf.RetryBlockedInteraction),
     Entry("ProcessIndexProtocol.ResolveBlockedInteraction", classOf[ProcessIndexProtocol.ResolveBlockedInteraction], actor.process_index.protobuf.ResolveBlockedInteraction),
 
-
     Entry("ProcessIndexProtocol.ProcessEventResponse", classOf[ProcessIndexProtocol.ProcessEventResponse], actor.process_index.protobuf.ProcessEventResponse),
     Entry("ProcessIndexProtocol.GetProcessState", classOf[ProcessIndexProtocol.GetProcessState], actor.process_index.protobuf.GetProcessState),
     Entry("ProcessIndexProtocol.GetCompiledRecipe", classOf[ProcessIndexProtocol.GetCompiledRecipe], actor.process_index.protobuf.GetCompiledRecipe),
@@ -74,8 +73,7 @@ class BakerProtobufSerializer(system: ExtendedActorSystem) extends SerializerWit
     Entry("ProcessInstanceProtocol.AlreadyInitialized", classOf[ProcessInstanceProtocol.AlreadyInitialized], actor.process_instance.protobuf.AlreadyInitialized),
 
     Entry("ProcessInstanceProtocol.FireTransition", classOf[ProcessInstanceProtocol.FireTransition], actor.process_instance.protobuf.FireTransition),
-    Entry("ProcessInstanceProtocol.RetryBlockedJob", classOf[ProcessInstanceProtocol.RetryBlockedJob], actor.process_instance.protobuf.RetryBlockedJob),
-    Entry("ProcessInstanceProtocol.ResolveBlockedJob", classOf[ProcessInstanceProtocol.ResolveBlockedJob], actor.process_instance.protobuf.ResolveBlockedJob),
+    Entry("ProcessInstanceProtocol.OverrideExceptionStrategy", classOf[ProcessInstanceProtocol.OverrideExceptionStrategy], actor.process_instance.protobuf.OverrideExceptionStrategy),
     Entry("ProcessInstanceProtocol.InvalidCommand", classOf[ProcessInstanceProtocol.InvalidCommand], actor.process_instance.protobuf.InvalidCommand),
 
     Entry("ProcessInstanceProtocol.AlreadyReceived", classOf[ProcessInstanceProtocol.AlreadyReceived], actor.process_instance.protobuf.AlreadyReceived),

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/BakerProtobufSerializer.scala
@@ -51,6 +51,10 @@ class BakerProtobufSerializer(system: ExtendedActorSystem) extends SerializerWit
     Entry("ProcessIndexProtocol.Index", classOf[ProcessIndexProtocol.Index], actor.process_index.protobuf.Index),
     Entry("ProcessIndexProtocol.CreateProcess", classOf[ProcessIndexProtocol.CreateProcess], actor.process_index.protobuf.CreateProcess),
     Entry("ProcessIndexProtocol.ProcessEvent", classOf[ProcessIndexProtocol.ProcessEvent], actor.process_index.protobuf.ProcessEvent),
+    Entry("ProcessIndexProtocol.RetryBlockedInteraction", classOf[ProcessIndexProtocol.RetryBlockedInteraction], actor.process_index.protobuf.RetryBlockedInteraction),
+    Entry("ProcessIndexProtocol.ResolveBlockedInteraction", classOf[ProcessIndexProtocol.ResolveBlockedInteraction], actor.process_index.protobuf.ResolveBlockedInteraction),
+
+
     Entry("ProcessIndexProtocol.ProcessEventResponse", classOf[ProcessIndexProtocol.ProcessEventResponse], actor.process_index.protobuf.ProcessEventResponse),
     Entry("ProcessIndexProtocol.GetProcessState", classOf[ProcessIndexProtocol.GetProcessState], actor.process_index.protobuf.GetProcessState),
     Entry("ProcessIndexProtocol.GetCompiledRecipe", classOf[ProcessIndexProtocol.GetCompiledRecipe], actor.process_index.protobuf.GetCompiledRecipe),
@@ -70,6 +74,10 @@ class BakerProtobufSerializer(system: ExtendedActorSystem) extends SerializerWit
     Entry("ProcessInstanceProtocol.AlreadyInitialized", classOf[ProcessInstanceProtocol.AlreadyInitialized], actor.process_instance.protobuf.AlreadyInitialized),
 
     Entry("ProcessInstanceProtocol.FireTransition", classOf[ProcessInstanceProtocol.FireTransition], actor.process_instance.protobuf.FireTransition),
+    Entry("ProcessInstanceProtocol.RetryBlockedJob", classOf[ProcessInstanceProtocol.RetryBlockedJob], actor.process_instance.protobuf.RetryBlockedJob),
+    Entry("ProcessInstanceProtocol.ResolveBlockedJob", classOf[ProcessInstanceProtocol.ResolveBlockedJob], actor.process_instance.protobuf.ResolveBlockedJob),
+    Entry("ProcessInstanceProtocol.InvalidCommand", classOf[ProcessInstanceProtocol.InvalidCommand], actor.process_instance.protobuf.InvalidCommand),
+
     Entry("ProcessInstanceProtocol.AlreadyReceived", classOf[ProcessInstanceProtocol.AlreadyReceived], actor.process_instance.protobuf.AlreadyReceived),
     Entry("ProcessInstanceProtocol.TransitionNotEnabled", classOf[ProcessInstanceProtocol.TransitionNotEnabled], actor.process_instance.protobuf.TransitionNotEnabled),
     Entry("ProcessInstanceProtocol.TransitionFailed", classOf[ProcessInstanceProtocol.TransitionFailed], actor.process_instance.protobuf.TransitionFailedMessage),

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessIndexModule.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessIndexModule.scala
@@ -52,6 +52,9 @@ class ProcessIndexModule extends ProtoEventAdapterModule {
     case protocol.ResolveBlockedInteraction(processId, interactionName, event) =>
       protobuf.ResolveBlockedInteraction(Some(processId), Some(interactionName), Some(ctx.toProto[RuntimeEvent](event)))
 
+    case protocol.StopRetryingInteraction(processId, interactionName) =>
+      protobuf.StopRetryingInteraction(Some(processId), Some(interactionName))
+
     case protocol.ProcessEventResponse(processId, sourceRef) =>
       val serializedSourceRef = ctx.toProtoAny(sourceRef)
       protobuf.ProcessEventResponse(Some(processId), Some(serializedSourceRef))
@@ -115,6 +118,9 @@ class ProcessIndexModule extends ProtoEventAdapterModule {
 
     case protobuf.ResolveBlockedInteraction(Some(processId), Some(interactionName), Some(event)) =>
       protocol.ResolveBlockedInteraction(processId, interactionName, ctx.toDomain[core.RuntimeEvent](event))
+
+    case protobuf.StopRetryingInteraction(Some(processId), Some(interactionName)) =>
+      protocol.StopRetryingInteraction(processId, interactionName)
 
     case protobuf.ProcessEventResponse(Some(processId), Some(sourceRef)) =>
       val deserializedSourceRef = ctx.toDomain[SourceRef[Any]](sourceRef)

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
@@ -50,7 +50,6 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
     case protocol.ExceptionState(failureCount, failureReason, failureStrategy) =>
       protobuf.ExceptionState(Some(failureCount), Some(failureReason), Some(ctx.toProto[protobuf.FailureStrategyMessage](failureStrategy)))
     case exceptionStrategy: ExceptionStrategy => exceptionStrategy match {
-      case ExceptionStrategy.Fatal => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.FATAL), None)
       case ExceptionStrategy.BlockTransition => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.BLOCK_TRANSITION), None)
       case ExceptionStrategy.Continue(marking, output) => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.CONTINUE), None, toProtoMarking(marking, ctx), Some(ctx.toProtoAny(output.asInstanceOf[AnyRef])))
       case ExceptionStrategy.RetryWithDelay(delay) => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.RETRY), Some(delay))
@@ -110,8 +109,6 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
       protocol.JobState(jobId, transitionId, toDomainMarking(consumed, ctx), ctx.toDomain[Any](input), exceptionState.map(ctx.toDomain[protocol.ExceptionState]))
     case protobuf.ExceptionState(Some(failureCount), Some(failureReason), Some(strategy)) =>
       protocol.ExceptionState(failureCount, failureReason, ctx.toDomain[ExceptionStrategy](strategy))
-    case protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.FATAL), _, _, _) =>
-      protocol.ExceptionStrategy.Fatal
     case protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.BLOCK_TRANSITION), _, _, _) =>
       protocol.ExceptionStrategy.BlockTransition
     case protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.RETRY), Some(retryDelay), _, _) =>

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
@@ -28,10 +28,9 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
     case protocol.FireTransition(transitionid, input, correlationId) =>
       protobuf.FireTransition(Some(transitionid), Some(ctx.toProtoAny(input.asInstanceOf[AnyRef])), correlationId)
 
-    case protocol.RetryBlockedJob(jobId) =>
-      protobuf.RetryBlockedJob(Some(jobId))
-    case protocol.ResolveBlockedJob(jobId, marking, output) =>
-      protobuf.ResolveBlockedJob(Some(jobId), toProtoMarking(marking, ctx), Some(ctx.toProtoAny(output.asInstanceOf[AnyRef])))
+    case protocol.OverrideExceptionStrategy(jobId, strategy) =>
+      protobuf.OverrideExceptionStrategy(Some(jobId), Some(ctx.toProto[protobuf.FailureStrategyMessage](strategy)))
+
     case protocol.InvalidCommand(reason) =>
       protobuf.InvalidCommand(Some(reason))
 
@@ -100,10 +99,8 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
     case protobuf.FireTransition(Some(transitionId), Some(input), correlationId) =>
       protocol.FireTransition(transitionId, ctx.toDomain[Any](input), correlationId)
 
-    case protobuf.RetryBlockedJob(Some(jobId)) =>
-      protocol.RetryBlockedJob(jobId)
-    case protobuf.ResolveBlockedJob(Some(jobId), produced, Some(output)) =>
-      protocol.ResolveBlockedJob(jobId, toDomainMarking(produced, ctx), ctx.toDomain[Any](output))
+    case protobuf.OverrideExceptionStrategy(Some(jobId), Some(failureStrategyMessage)) =>
+      protocol.OverrideExceptionStrategy(jobId, ctx.toDomain[protocol.ExceptionStrategy](failureStrategyMessage))
     case protobuf.InvalidCommand(Some(reason)) =>
       protocol.InvalidCommand(reason)
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/serialization/modules/ProcessInstanceModule.scala
@@ -25,9 +25,16 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
         protobuf.AlreadyInitialized(Some(processId))
     case protocol.Uninitialized(processId) =>
         protobuf.Uninitialized(Some(processId))
-
     case protocol.FireTransition(transitionid, input, correlationId) =>
       protobuf.FireTransition(Some(transitionid), Some(ctx.toProtoAny(input.asInstanceOf[AnyRef])), correlationId)
+
+    case protocol.RetryBlockedJob(jobId) =>
+      protobuf.RetryBlockedJob(Some(jobId))
+    case protocol.ResolveBlockedJob(jobId, marking, output) =>
+      protobuf.ResolveBlockedJob(Some(jobId), toProtoMarking(marking, ctx), Some(ctx.toProtoAny(output.asInstanceOf[AnyRef])))
+    case protocol.InvalidCommand(reason) =>
+      protobuf.InvalidCommand(Some(reason))
+
     case protocol.AlreadyReceived(correlationId) =>
       protobuf.AlreadyReceived(Some(correlationId))
     case protocol.TransitionNotEnabled(transitionId, reason) =>
@@ -92,6 +99,14 @@ class ProcessInstanceModule extends ProtoEventAdapterModule {
 
     case protobuf.FireTransition(Some(transitionId), Some(input), correlationId) =>
       protocol.FireTransition(transitionId, ctx.toDomain[Any](input), correlationId)
+
+    case protobuf.RetryBlockedJob(Some(jobId)) =>
+      protocol.RetryBlockedJob(jobId)
+    case protobuf.ResolveBlockedJob(Some(jobId), produced, Some(output)) =>
+      protocol.ResolveBlockedJob(jobId, toDomainMarking(produced, ctx), ctx.toDomain[Any](output))
+    case protobuf.InvalidCommand(Some(reason)) =>
+      protocol.InvalidCommand(reason)
+
     case protobuf.AlreadyReceived(Some(correlationId)) =>
       protocol.AlreadyReceived(correlationId)
     case protobuf.TransitionNotEnabled(Some(transitionId), Some(reason)) =>

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -273,6 +273,18 @@ class Baker()(implicit val actorSystem: ActorSystem) {
   }
 
   /**
+    * Stops the retrying of an interaction.
+    *
+    * @return
+    */
+  def stopRetryingInteraction(processId: String, interactionName: String, timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
+
+    val futureResult = processIndexActor.ask(StopRetryingInteraction(processId, interactionName))(timeout)
+
+    Await.result(futureResult, timeout)
+  }
+
+  /**
     * Synchronously returns all event names that occurred for a process.
     */
   def eventNames(processId: String, timeout: FiniteDuration = defaultInquireTimeout): List[String] =

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -249,6 +249,28 @@ class Baker()(implicit val actorSystem: ActorSystem) {
   }
 
   /**
+    * Retries a blocked interaction.
+    *
+    * @return
+    */
+  def retryBlockedInteraction(processId: String, interactionName: String)(timeout: FiniteDuration = defaultProcessEventTimeout) = {
+
+    processIndexActor.ask(RetryBlockedInteraction(processId, interactionName))(timeout)
+  }
+
+  /**
+    * Retries a blocked interaction.
+    *
+    * @return
+    */
+  def resolveBlockedInteraction(processId: String, interactionName: String, event: Any)(timeout: FiniteDuration = defaultProcessEventTimeout) = {
+
+    val futureResult = processIndexActor.ask(ResolveBlockedInteraction(processId, interactionName, extractEvent(event)))(timeout)
+
+    Await.result(futureResult, timeout)
+  }
+
+  /**
     * Synchronously returns all event names that occurred for a process.
     */
   def eventNames(processId: String, timeout: FiniteDuration = defaultInquireTimeout): List[String] =

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -253,17 +253,19 @@ class Baker()(implicit val actorSystem: ActorSystem) {
     *
     * @return
     */
-  def retryBlockedInteraction(processId: String, interactionName: String)(timeout: FiniteDuration = defaultProcessEventTimeout) = {
+  def retryInteraction(processId: String, interactionName: String)(timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
 
-    processIndexActor.ask(RetryBlockedInteraction(processId, interactionName))(timeout)
+    val futureResult = processIndexActor.ask(RetryBlockedInteraction(processId, interactionName))(timeout)
+
+    Await.result(futureResult, timeout)
   }
 
   /**
-    * Retries a blocked interaction.
+    * Resolves a blocked interaction by specifying it's output.
     *
     * @return
     */
-  def resolveBlockedInteraction(processId: String, interactionName: String, event: Any)(timeout: FiniteDuration = defaultProcessEventTimeout) = {
+  def resolveInteraction(processId: String, interactionName: String, event: Any)(timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
 
     val futureResult = processIndexActor.ask(ResolveBlockedInteraction(processId, interactionName, extractEvent(event)))(timeout)
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -375,11 +375,10 @@ class Baker()(implicit val actorSystem: ActorSystem) {
     processIndexActor
       .ask(GetProcessState(processId))(Timeout.durationToTimeout(timeout))
       .flatMap {
-        case instane: InstanceState   => Future.successful(instane.state.asInstanceOf[ProcessState])
-        case Uninitialized(id)        => Future.failed(new NoSuchProcessException(s"No such process with: $id"))
-        case NoSuchProcess(id)        => Future.failed(new NoSuchProcessException(s"No such process with: $id"))
-        case ProcessDeleted(id)       => Future.failed(new ProcessDeletedException(s"Process $id is deleted"))
-        case msg                      => Future.failed(new BakerException(s"Unexpected actor response message: $msg"))
+        case instance: InstanceState => Future.successful(instance.state.asInstanceOf[ProcessState])
+        case NoSuchProcess(id)       => Future.failed(new NoSuchProcessException(s"No such process with: $id"))
+        case ProcessDeleted(id)      => Future.failed(new ProcessDeletedException(s"Process $id is deleted"))
+        case msg                     => Future.failed(new BakerException(s"Unexpected actor response message: $msg"))
       }
   }
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -253,7 +253,7 @@ class Baker()(implicit val actorSystem: ActorSystem) {
     *
     * @return
     */
-  def retryInteraction(processId: String, interactionName: String)(timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
+  def retryInteraction(processId: String, interactionName: String, timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
 
     val futureResult = processIndexActor.ask(RetryBlockedInteraction(processId, interactionName))(timeout)
 
@@ -265,7 +265,7 @@ class Baker()(implicit val actorSystem: ActorSystem) {
     *
     * @return
     */
-  def resolveInteraction(processId: String, interactionName: String, event: Any)(timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
+  def resolveInteraction(processId: String, interactionName: String, event: Any, timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {
 
     val futureResult = processIndexActor.ask(ResolveBlockedInteraction(processId, interactionName, extractEvent(event)))(timeout)
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/BakerResponse.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/BakerResponse.scala
@@ -22,7 +22,6 @@ object BakerResponse {
     response.map(translateFirstMessage)
 
   private def translateFirstMessage(msg: Any): SensoryEventStatus = msg match {
-    case ProcessInstanceProtocol.Uninitialized(processId) => throw new NoSuchProcessException(s"No such process: $processId")
     case _: ProcessInstanceProtocol.TransitionFired => SensoryEventStatus.Received
     case _: ProcessInstanceProtocol.TransitionNotEnabled => SensoryEventStatus.FiringLimitMet
     case _: ProcessInstanceProtocol.AlreadyReceived => SensoryEventStatus.AlreadyReceived

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/ProcessState.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/ProcessState.scala
@@ -1,5 +1,6 @@
 package com.ing.baker.runtime.core
 
+import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome
 import com.ing.baker.types.Value
 
 import scala.collection.JavaConverters._

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
@@ -84,7 +84,9 @@ class InteractionTaskProvider(recipe: CompiledRecipe, interactionManager: Intera
           val interactionOutput: Option[RuntimeEvent] = implementation.execute(input)
 
           // validates the event, throws a FatalInteraction exception if invalid
-          RecipeRuntime.validateEvent(interaction, interactionOutput)
+          RecipeRuntime.validateEvent(interaction, interactionOutput).foreach { validationError =>
+            throw new FatalInteractionException(validationError)
+          }
 
           // transform the event if there is one
           val outputEvent: Option[RuntimeEvent] = interactionOutput

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
@@ -84,7 +84,7 @@ class InteractionTaskProvider(recipe: CompiledRecipe, interactionManager: Intera
           val interactionOutput: Option[RuntimeEvent] = implementation.execute(input)
 
           // validates the event, throws a FatalInteraction exception if invalid
-          RecipeRuntime.validateEvent(interaction, interactionOutput).foreach { validationError =>
+          RecipeRuntime.validateInteractionOutput(interaction, interactionOutput).foreach { validationError =>
             throw new FatalInteractionException(validationError)
           }
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/InteractionTaskProvider.scala
@@ -54,43 +54,6 @@ class InteractionTaskProvider(recipe: CompiledRecipe, interactionManager: Intera
     }
   }
 
-  /**
-    * Validates the output event of an interaction
-    *
-    * @throws FatalInteractionException If the event was invalid.
-    */
-  def validateEvent(interaction: InteractionTransition, optionalEvent: Option[RuntimeEvent]) = {
-
-    optionalEvent match {
-
-      case None =>
-        // an event was expected but none was provided
-        if (!interaction.eventsToFire.isEmpty)
-          throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' did not provide any output, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
-
-      case Some(event) =>
-
-        val nullIngredientNames = event.providedIngredients.collect {
-          case (name, null) => name
-        }
-
-        // null values for ingredients are NOT allowed
-        if(nullIngredientNames.nonEmpty)
-          throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' returned null for the following ingredients: ${nullIngredientNames.mkString(",")}")
-
-        // the event name must match an event name from the interaction output
-        interaction.originalEvents.find(_.name == event.name) match {
-          case None =>
-            throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' returned unkown event '${event.name}, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
-          case Some(eventType) =>
-            val errors = event.validateEvent(eventType)
-
-            if (errors.nonEmpty)
-              throw new FatalInteractionException(s"Event '${event.name}' does not match the expected type: ${errors.mkString}")
-        }
-    }
-  }
-
   def interactionTask(interaction: InteractionTransition,
                       outAdjacent: MultiSet[Place],
                       processState: ProcessState): IO[(Marking[Place], RuntimeEvent)] = {
@@ -121,7 +84,7 @@ class InteractionTaskProvider(recipe: CompiledRecipe, interactionManager: Intera
           val interactionOutput: Option[RuntimeEvent] = implementation.execute(input)
 
           // validates the event, throws a FatalInteraction exception if invalid
-          validateEvent(interaction, interactionOutput)
+          RecipeRuntime.validateEvent(interaction, interactionOutput)
 
           // transform the event if there is one
           val outputEvent: Option[RuntimeEvent] = interactionOutput

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/MethodInteractionImplementation.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/MethodInteractionImplementation.scala
@@ -17,8 +17,8 @@ case class MethodInteractionImplementation(implementation: AnyRef) extends Inter
     val unmockedClass = unmock(implementation.getClass)
 
     unmockedClass.getMethods.count(_.getName == "apply") match {
-      case 0          => throw new BakerException("Method does not have a apply function")
-      case n if n > 1 => throw new BakerException("Method has multiple apply functions")
+      case 0          => throw new IllegalArgumentException("Implementation does not have a apply function")
+      case n if n > 1 => throw new IllegalArgumentException("Implementation has multiple apply functions")
       case _          => unmockedClass.getMethods.find(_.getName == "apply").get
     }
   }

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/MethodInteractionImplementation.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/MethodInteractionImplementation.scala
@@ -2,7 +2,7 @@ package com.ing.baker.runtime.core.internal
 
 import java.util.UUID
 
-import com.ing.baker.runtime.core.{BakerException, RuntimeEvent, _}
+import com.ing.baker.runtime.core.{RuntimeEvent, _}
 import com.ing.baker.types.{Converters, Type, Value}
 import org.slf4j.LoggerFactory
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
@@ -43,7 +43,7 @@ object RecipeRuntime {
     *
     * Returns an optional error message.
     */
-  def validateEvent(interaction: InteractionTransition, optionalEvent: Option[RuntimeEvent]): Option[String] = {
+  def validateInteractionOutput(interaction: InteractionTransition, optionalEvent: Option[RuntimeEvent]): Option[String] = {
 
     optionalEvent match {
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
@@ -37,6 +37,43 @@ object RecipeRuntime {
       place -> MultiSet.copyOff(Seq(value))
     }.toMarking
   }
+
+  /**
+    * Validates the output event of an interaction
+    *
+    * @throws FatalInteractionException If the event was invalid.
+    */
+  def validateEvent(interaction: InteractionTransition, optionalEvent: Option[RuntimeEvent]): Unit = {
+
+    optionalEvent match {
+
+      case None =>
+        // an event was expected but none was provided
+        if (!interaction.eventsToFire.isEmpty)
+          throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' did not provide any output, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
+
+      case Some(event) =>
+
+        val nullIngredientNames = event.providedIngredients.collect {
+          case (name, null) => name
+        }
+
+        // null values for ingredients are NOT allowed
+        if(nullIngredientNames.nonEmpty)
+          throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' returned null for the following ingredients: ${nullIngredientNames.mkString(",")}")
+
+        // the event name must match an event name from the interaction output
+        interaction.originalEvents.find(_.name == event.name) match {
+          case None =>
+            throw new FatalInteractionException(s"Interaction '${interaction.interactionName}' returned unkown event '${event.name}, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
+          case Some(eventType) =>
+            val errors = event.validateEvent(eventType)
+
+            if (errors.nonEmpty)
+              throw new FatalInteractionException(s"Event '${event.name}' does not match the expected type: ${errors.mkString}")
+        }
+    }
+  }
 }
 
 class RecipeRuntime(recipe: CompiledRecipe, interactionManager: InteractionManager, eventStream: EventStream) extends ProcessInstanceRuntime[Place, Transition, ProcessState, RuntimeEvent] {

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
@@ -67,7 +67,7 @@ object RecipeRuntime {
         // the event name must match an event name from the interaction output
         interaction.originalEvents.find(_.name == event.name) match {
           case None =>
-            Some(s"Interaction '${interaction.interactionName}' returned unkown event '${event.name}, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
+            Some(s"Interaction '${interaction.interactionName}' returned unknown event '${event.name}, expected one of: ${interaction.eventsToFire.map(_.name).mkString(",")}")
           case Some(eventType) =>
             val errors = event.validateEvent(eventType)
 

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -328,6 +328,49 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
 
 
   /**
+    * Retries a blocked interaction.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the blocked interaction.
+    * @return
+    */
+  def retryInteraction(@Nonnull processId: String, @Nonnull interactionName: String): Unit =
+    baker.retryInteraction(processId, interactionName)
+
+  /**
+    * Retries a blocked interaction.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the blocked interaction.
+    * @return
+    */
+  def retryInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull timeout: java.time.Duration): Unit =
+    baker.retryInteraction(processId, interactionName)(timeout.toScala)
+
+  /**
+    * Resolves a blocked interaction by giving it's output.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the blocked interaction.
+    * @param event The output of the interaction.
+    * @return
+    */
+  def resolveInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull event: Any): Unit =
+    baker.resolveInteraction(processId, interactionName, event)
+
+  /**
+    * Resolves a blocked interaction by giving it's output.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the blocked interaction.
+    * @param event The output of the interaction.
+    * @return
+    */
+  def resolveInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull event: Any, @Nonnull timeout: java.time.Duration): Unit =
+    baker.resolveInteraction(processId, interactionName, event)(timeout.toScala)
+
+
+  /**
     * Returns all the ingredients that are accumulated for a given process.
     *
     * @param processId The process identifier

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -369,6 +369,26 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   def resolveInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull event: Any, @Nonnull timeout: java.time.Duration): Unit =
     baker.resolveInteraction(processId, interactionName, event, timeout.toScala)
 
+  /**
+    * Stops a retrying interaction.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the retrying interaction.
+    * @return
+    */
+  def stopRetryingInteraction(@Nonnull processId: String, @Nonnull interactionName: String): Unit =
+    baker.stopRetryingInteraction(processId, interactionName)
+
+  /**
+    * Resolves a blocked interaction by giving it's output.
+    *
+    * @param processId The process identifier.
+    * @param interactionName The name of the retrying interaction.
+    * @param timeout       How long to wait for a response from the process
+    * @return
+    */
+  def stopRetryingInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull timeout: java.time.Duration): Unit =
+    baker.stopRetryingInteraction(processId, interactionName, timeout.toScala)
 
   /**
     * Returns all the ingredients that are accumulated for a given process.

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -345,7 +345,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
     * @return
     */
   def retryInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull timeout: java.time.Duration): Unit =
-    baker.retryInteraction(processId, interactionName)(timeout.toScala)
+    baker.retryInteraction(processId, interactionName, timeout.toScala)
 
   /**
     * Resolves a blocked interaction by giving it's output.
@@ -367,7 +367,7 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
     * @return
     */
   def resolveInteraction(@Nonnull processId: String, @Nonnull interactionName: String, @Nonnull event: Any, @Nonnull timeout: java.time.Duration): Unit =
-    baker.resolveInteraction(processId, interactionName, event)(timeout.toScala)
+    baker.resolveInteraction(processId, interactionName, event, timeout.toScala)
 
 
   /**

--- a/runtime/src/test/java/com/ing/baker/JBakerTest.java
+++ b/runtime/src/test/java/com/ing/baker/JBakerTest.java
@@ -118,6 +118,7 @@ public class JBakerTest {
         String processStringId = UUID.randomUUID().toString();
         String testEvent = "testEvent";
         String testCorrelationId = "testCorrelationId";
+        String testInteractionName = "testInteraction";
         java.time.Duration testTimeout = java.time.Duration.ofSeconds(1);
         FiniteDuration testTimeoutScala = new FiniteDuration(testTimeout.toMillis(), TimeUnit.MILLISECONDS);
         EventListener testListener = (processId, event) -> {
@@ -227,6 +228,26 @@ public class JBakerTest {
 
         jBaker.processEvent(processUUID, testEvent, testCorrelationId, testTimeout);
         verify(mockBaker).processEvent(eq(processUUID.toString()), eq(testEvent), eq(Option.apply(testCorrelationId)), eq(testTimeoutScala));
+
+        // incident resolving
+
+        jBaker.retryInteraction(processStringId, testInteractionName);
+        verify(mockBaker).retryInteraction(eq(processStringId), eq(testInteractionName), any(FiniteDuration.class));
+
+        jBaker.retryInteraction(processStringId, testInteractionName, testTimeout);
+        verify(mockBaker).retryInteraction(eq(processStringId), eq(testInteractionName), eq(testTimeoutScala));
+
+        jBaker.resolveInteraction(processStringId, testInteractionName, testEvent);
+        verify(mockBaker).resolveInteraction(eq(processStringId), eq(testInteractionName), eq(testEvent), any(FiniteDuration.class));
+
+        jBaker.resolveInteraction(processStringId, testInteractionName, testEvent, testTimeout);
+        verify(mockBaker).resolveInteraction(eq(processStringId), eq(testInteractionName), eq(testEvent), eq(testTimeoutScala));
+
+        jBaker.stopRetryingInteraction(processStringId, testInteractionName);
+        verify(mockBaker).stopRetryingInteraction(eq(processStringId), eq(testInteractionName), any(FiniteDuration.class));
+
+        jBaker.stopRetryingInteraction(processStringId, testInteractionName, testTimeout);
+        verify(mockBaker).stopRetryingInteraction(eq(processStringId), eq(testInteractionName), eq(testTimeoutScala));
     }
 
     @Test

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
@@ -203,7 +203,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
         case Some(ExceptionState(_, _, BlockTransition)) =>
       }
 
-      actor ! RetryBlockedTransition(jobId)
+      actor ! RetryBlockedJob(jobId)
 
       // expect that the failure is resolved
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _, _) ⇒ }
@@ -235,7 +235,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
         case Some(ExceptionState(_, _, BlockTransition)) =>
       }
 
-      actor ! ResolveBlockedTransition(jobId, place(2).markWithN(1).marshall, Added(2))
+      actor ! ResolveBlockedJob(jobId, place(2).markWithN(1).marshall, Added(2))
 
       // expect that the failure is resolved
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _, Added(2)) ⇒ }

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
@@ -433,7 +433,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
     "Block a transition if the exception strategy function throws an exception" in new TestSequenceNet {
 
       val faultyExceptionHandler: TransitionExceptionHandler[Place] = {
-        case (_, _, _) ⇒ throw new IllegalStateException("Boom!")
+        case (_, _, _) ⇒ throw new IllegalStateException("Expected test failure")
       }
 
       override def sequence =

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
@@ -235,7 +235,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
         case Some(ExceptionState(_, _, BlockTransition)) =>
       }
 
-      actor ! ResolveFailure(jobId, place(2).markWithN(1).marshall, Added(2))
+      actor ! ResolveBlockedTransition(jobId, place(2).markWithN(1).marshall, Added(2))
 
       // expect that the failure is resolved
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _, Added(2)) ⇒ }

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/ProcessInstanceSpec.scala
@@ -203,7 +203,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
         case Some(ExceptionState(_, _, BlockTransition)) =>
       }
 
-      actor ! RetryBlockedJob(jobId)
+      actor ! OverrideExceptionStrategy(jobId, protocol.ExceptionStrategy.RetryWithDelay(0))
 
       // expect that the failure is resolved
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _, _) ⇒ }
@@ -235,7 +235,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
         case Some(ExceptionState(_, _, BlockTransition)) =>
       }
 
-      actor ! ResolveBlockedJob(jobId, place(2).markWithN(1).marshall, Added(2))
+      actor ! OverrideExceptionStrategy(jobId, protocol.ExceptionStrategy.Continue(place(2).markWithN(1).marshall, Added(2)))
 
       // expect that the failure is resolved
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _, Added(2)) ⇒ }

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/dsl/StateTransitionNet.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/process_instance/dsl/StateTransitionNet.scala
@@ -24,7 +24,7 @@ trait StateTransitionNet[S, E] {
                                 (throwable: Throwable, failureCount: Int, startTime: Long, outMarking: MultiSet[Place]) =
       job.transition.exceptionStrategy(throwable, failureCount, outMarking)
     override def isAutoFireable(instance: Instance[Place, Transition, S], t: Transition): Boolean =
-      t.isAutomated && instance.isBlockedReason(t).isEmpty
+      t.isAutomated && !instance.isBlocked(t)
   }
 
   def stateTransition(id: Long = Math.abs(Random.nextLong), label: Option[String] = None, automated: Boolean = false,

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
@@ -159,9 +159,14 @@ object ProtoEventAdapterSpec {
       event <- Runtime.runtimeEventGen
     } yield ResolveBlockedInteraction(processId, interactionName, event)
 
+    val stopRetryingInteractionGen = for {
+      processId <- processIdGen
+      interactionName <- Gen.alphaStr
+    } yield StopRetryingInteraction(processId, interactionName)
+
     val messagesGen: Gen[AnyRef] = Gen.oneOf(getIndexGen, indexGen, createProcessGen, processEventGen,
       getProcessStateGen, getCompiledRecipeGen, receivePeriodExpiredGen, invalidEventGen, processDeletedGen,
-      noSuchProcessGen, processAlreadyExistsGen, retryBlockedInteractionGen, resolveBlockedInteraction)
+      noSuchProcessGen, processAlreadyExistsGen, retryBlockedInteractionGen, resolveBlockedInteraction, stopRetryingInteractionGen)
   }
 
   object ProcessInstance {

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
@@ -253,13 +253,10 @@ object ProtoEventAdapterSpec {
       strategy <- failureStrategyGen
     } yield TransitionFailed(jobId, transitionId, correlationId, consume, input, reason, strategy)
 
-    val retryJobGen = jobIdGen.map(RetryBlockedJob(_))
-
-    val resolveJobGen = for {
+    val overrideFailureGen = for {
       jobId <- jobIdGen
-      produced <- markingDataGen
-      output <- Runtime.runtimeEventGen
-    } yield ResolveBlockedJob(jobId, produced, output)
+      strategy <- failureStrategyGen
+    } yield OverrideExceptionStrategy(jobId, strategy)
 
     val invalidCommandGen = for {
       reason <- Gen.alphaStr
@@ -272,7 +269,7 @@ object ProtoEventAdapterSpec {
 
     val messagesGen: Gen[AnyRef] = Gen.oneOf(getStateGen, stopGen, initializeGen, initializedGen, uninitializedGen,
       alreadyInitializedGen, fireTransitionGen, transitionFiredGen, transitionFailedGen, transitionNotEnabledGen,
-      retryJobGen, resolveJobGen, invalidCommandGen)
+      overrideFailureGen, invalidCommandGen)
   }
 
   object Types {

--- a/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/actor/serialization/ProtoEventAdapterSpec.scala
@@ -200,7 +200,6 @@ object ProtoEventAdapterSpec {
 
     val failureStrategyGen: Gen[ExceptionStrategy] = Gen.oneOf(
       Gen.const(ExceptionStrategy.BlockTransition),
-      Gen.const(ExceptionStrategy.Fatal),
       Gen.posNum[Long].map(delay => ExceptionStrategy.RetryWithDelay(delay)),
       for {
         marking <- markingDataGen

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerEventsSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerEventsSpec.scala
@@ -12,9 +12,6 @@ import com.ing.baker.recipe.scaladsl.Recipe
 import com.ing.baker.runtime.core.events.RejectReason._
 import com.ing.baker.runtime.core.events._
 import com.ing.baker.types.PrimitiveValue
-import org.hamcrest
-import org.hamcrest.Description
-import org.mockito.Matchers
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerEventsSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerEventsSpec.scala
@@ -25,14 +25,6 @@ object BakerEventsSpec {
 
   val log = LoggerFactory.getLogger(classOf[BakerEventsSpec])
 
-  def matchPF[T](pf: PartialFunction[T, Any]) = Matchers.argThat(new hamcrest.BaseMatcher[T] {
-    override def matches(o: scala.Any): Boolean = pf.isDefinedAt(o.asInstanceOf[T])
-
-    override def describeTo(description: Description): Unit = {
-      description.appendValue(pf)
-    }
-  })
-
   def listenerFunction(probe: ActorRef, logEvents: Boolean = false): PartialFunction[BakerEvent, Unit] = {
     case event: BakerEvent =>
       if (logEvents) {

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -856,7 +856,7 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
         ingredientMap(
           "initialIngredient" -> initialIngredientValue)
 
-      baker.resolveBlockedInteraction(processId, interactionOne.name, InteractionOneSuccessful("success!"))(timeout)
+      baker.resolveInteraction(processId, interactionOne.name, InteractionOneSuccessful("success!"))(timeout)
 
       baker.getIngredients(processId) shouldBe
         ingredientMap(

--- a/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/core/BakerExecutionSpec.scala
@@ -866,7 +866,7 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
 
     "retry a blocked interaction" in {
       val recipe =
-        Recipe("RetrylockedInteractionRecipe")
+        Recipe("RetryBlockedInteractionRecipe")
           .withInteraction(interactionOne)
           .withSensoryEvent(initialEvent)
 


### PR DESCRIPTION
This is for incident handling and provides 2 ways to resolve blocked interactions.

1. Force retry: 
    ```baker.retryInteraction(processId, interactionName)```
2. Continue with event: 
    ```baker.resolveInteraction(processId, interactionName, event)```

Update: this PR now ready for review and merging.