### PR TITLE
Add link to documentation to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Developers declare the orchestration logic in a recipe.
 A recipe is made out of **interactions** (system calls), **ingredients** (data) and **events**.
 A visual representation (shown below) of the recipe allows product owners, architects and developers to talk the same language.
 
+The official documentation website of Baker: [Official Documentation](https://ing-bank.github.io/baker/).
+
 An introductory presentation of Baker: [Baker talk @ Amsterdam.Scala meetup](https://www.slideshare.net/BekirOguz/designing-process-flows-with-baker).
 
 A talk about Baker at the Scale By the Bay 2017 conference: [Declare, verify and execute microservices-based process flows](https://www.youtube.com/watch?v=0bWQwUmeXHU).


### PR DESCRIPTION
I suggest we also add it to the top of github.
You can specify specify a website next to the title.