### PR TITLE
WIP: Do not retry FatalInteractionException, fixes #125

### DIFF
--- a/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/internal/RecipeRuntime.scala
@@ -66,7 +66,7 @@ class RecipeRuntime(recipe: CompiledRecipe, interactionManager: InteractionManag
   override def handleException(job: Job[Place, Transition, ProcessState])
                               (throwable: Throwable, failureCount: Int, startTime: Long, outMarking: MultiSet[Place]): ExceptionStrategy = {
 
-    if (throwable.isInstanceOf[Error])
+    if (throwable.isInstanceOf[Error] || throwable.isInstanceOf[FatalInteractionException])
       BlockTransition
     else
       job.transition match {


### PR DESCRIPTION
Before merging consider. Is this desired behaviour?

Also a `FatalInteractionException` is thrown when no implementation is found for an interaction.

This may change during runtime, so it could be recoverer from by retrying.