### PR TITLE
Fix a bug relating to event renames and overriding interaction output

### DIFF
--- a/docs/documentation/process-execution.md
+++ b/docs/documentation/process-execution.md
@@ -161,8 +161,10 @@ baker.resolveInteraction(processId, "ShipGoods", GoodsShipped("some goods"))
 ```
 
 ``` java tab="Java"
-baker.resolveInteraction(processId, "ShipGoods", new GoodsSchipped("some goods"));
+baker.resolveInteraction(processId, "ShipGoods", new GoodsShipped("some goods"));
 ```
+
+Note that the event provided *SHOULD NOT* include any [event or ingredient renames](recipe-dsl.md#event-renames) specified for the interaction.
 
 
 ## State inquiry

--- a/docs/documentation/recipe-dsl.md
+++ b/docs/documentation/recipe-dsl.md
@@ -129,6 +129,23 @@ Each time all *remaining* ingredients are provided, the interaction will fire.
 
 You can **not** predefine *ALL* input ingredients of an interaction.
 
+### Event renames
+
+Sometimes it useful to rename an interaction event and/or its ingredients to fit better in the context of your recipe.
+
+For example, to rename the `GoodsManufactured` event and its ingredient.
+
+``` java
+  .withInteractions(
+    of(ManufactureGoods.class)
+      .withEventTransformation(
+        GoodsManufactured.class, "ManufacturingDone",
+        ImmutableMap.of("goods", "manufacturedGoods")
+      )
+    )
+  )
+```
+
 ### Event requirements
 
 As mentioned before, the DSL is declarative, you do not have to think about order. This is implicit in the data requirements of the interactions.

--- a/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/actor/process_index/ProcessIndex.scala
@@ -321,7 +321,9 @@ class ProcessIndex(processIdleTimeout: Option[FiniteDuration],
               case None        =>
                 val petriNet = getCompiledRecipe(index(processId).recipeId).get.petriNet
                 val producedMarking = RecipeRuntime.createProducedMarking(petriNet.outMarking(interaction), Some(event))
-                processActor.tell(OverrideExceptionStrategy(jobId, Continue(producedMarking.marshall, event)), originalSender)
+                val transformedEvent = RecipeRuntime.transformInteractionEvent(interaction, event)
+
+                processActor.tell(OverrideExceptionStrategy(jobId, Continue(producedMarking.marshall, transformedEvent)), originalSender)
               case Some(error) =>
                 log.warning("Invalid event given: " + error)
                 originalSender ! InvalidEvent(processId, error)

--- a/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/core/Baker.scala
@@ -263,6 +263,8 @@ class Baker()(implicit val actorSystem: ActorSystem) {
   /**
     * Resolves a blocked interaction by specifying it's output.
     *
+    * !!! You should provide an event of the original interaction. Event / ingredient renames are done by Baker.
+    *
     * @return
     */
   def resolveInteraction(processId: String, interactionName: String, event: Any, timeout: FiniteDuration = defaultProcessEventTimeout): Unit = {

--- a/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/java_api/JBaker.scala
@@ -361,6 +361,8 @@ class JBaker(private val baker: Baker, implementations: java.lang.Iterable[AnyRe
   /**
     * Resolves a blocked interaction by giving it's output.
     *
+    * !!! You should provide an event of the original interaction. Event / ingredient renames are done by Baker.
+    *
     * @param processId The process identifier.
     * @param interactionName The name of the blocked interaction.
     * @param event The output of the interaction.


### PR DESCRIPTION
Event / ingredient renames where not taken into account in the *resolveInteraction* feature from `2.0.3`