### PR TITLE
Fix dependency convergence mismatch

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,8 +41,8 @@ object Dependencies {
   val scalaGraphDot =             "org.scala-graph"            %% "graph-dot"                          % "1.11.5"
   val graphvizJava =              "guru.nidi"                  %  "graphviz-java"                      % "0.8.0"
 
-  val catsEffect =                "org.typelevel"              %% "cats-effect"                        % "0.10"
-  val catsCore =                  "org.typelevel"              %% "cats-core"                          % "1.1.0"
+  val catsEffect =                "org.typelevel"              %% "cats-effect"                        % "1.2.0"
+  val catsCore =                  "org.typelevel"              %% "cats-core"                          % "1.5.0"
 
   def scalaReflect(scalaV: String): ModuleID = "org.scala-lang"%  "scala-reflect"                      % scalaV
   val javaxInject =               "javax.inject"               %  "javax.inject"                       % "1"


### PR DESCRIPTION
issue:
```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability the error(s) are [
Dependency convergence error for org.typelevel:cats-core_2.12:1.1.0 paths to dependency are:
+-com.ing.currentaccounts:pCurrentAccountOpenJointAPI-Recipe:00.00.01.003-SNAPSHOT
  +-com.ing.baker:baker-runtime_2.12:2.0.5
    +-org.typelevel:cats-core_2.12:1.1.0
and
+-com.ing.currentaccounts:pCurrentAccountOpenJointAPI-Recipe:00.00.01.003-SNAPSHOT
  +-com.ing.baker:baker-runtime_2.12:2.0.5
    +-org.typelevel:cats-effect_2.12:0.10
      +-org.typelevel:cats-core_2.12:1.0.1
```
fix: 
- Use a new version of cats-effect.
- Use the cats-core version that matches the cats-effect version.