### PR TITLE
Update cats-effect to 2.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val circe =                     "io.circe"                   %% "circe-core"                         % circeVersion
   val circeGeneric =              "io.circe"                   %% "circe-generic"                      % circeVersion
 
-  val catsEffect =                "org.typelevel"              %% "cats-effect"                        % "1.4.0"
+  val catsEffect =                "org.typelevel"              %% "cats-effect"                        % "2.0.0"
   val catsCore =                  "org.typelevel"              %% "cats-core"                          % "2.0.0"
 
   def scalaReflect(scalaV: String): ModuleID = "org.scala-lang"%  "scala-reflect"                      % scalaV

--- a/runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
@@ -3,7 +3,7 @@ package com.ing.baker.runtime.akka.internal
 import java.lang.reflect.InvocationTargetException
 
 import akka.event.EventStream
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import com.ing.baker.il
 import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome
 import com.ing.baker.il.petrinet._
@@ -120,6 +120,7 @@ object RecipeRuntime {
 
 class RecipeRuntime(recipe: CompiledRecipe, interactionManager: InteractionManager, eventStream: EventStream)(implicit ec: ExecutionContext) extends ProcessInstanceRuntime[Place, Transition, RecipeInstanceState, EventInstance] {
 
+  protected implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(ec)
   /**
     * All transitions except sensory event interactions are auto-fireable by the runtime
     */


### PR DESCRIPTION
Updates org.typelevel:cats-effect from 1.4.0 to 2.0.0.
Release Notes/Changelog