### PR TITLE
Skuber and watch for service discovery

### DIFF
--- a/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
+++ b/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
@@ -1,8 +1,8 @@
 package com.ing.baker.baas.state
 
 import akka.actor.ActorSystem
-import akka.stream.{KillSwitches, Materializer}
 import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.{KillSwitches, Materializer}
 import cats.effect.concurrent.Ref
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.implicits._
@@ -14,14 +14,11 @@ import com.ing.baker.il.petrinet.InteractionTransition
 import com.ing.baker.runtime.akka.internal.InteractionManager
 import com.ing.baker.runtime.scaladsl.{Baker, InteractionInstance}
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Stream
 import org.http4s.Uri
 import skuber._
-import skuber.json.format._
 import skuber.api.client.{EventType, KubernetesClient}
+import skuber.json.format._
 
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 object ServiceDiscovery extends LazyLogging {

--- a/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
+++ b/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
@@ -1,5 +1,8 @@
 package com.ing.baker.baas.state
 
+import akka.actor.ActorSystem
+import akka.stream.{KillSwitches, Materializer}
+import akka.stream.scaladsl.{Keep, Sink}
 import cats.effect.concurrent.Ref
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.implicits._
@@ -12,11 +15,10 @@ import com.ing.baker.runtime.akka.internal.InteractionManager
 import com.ing.baker.runtime.scaladsl.{Baker, InteractionInstance}
 import com.typesafe.scalalogging.LazyLogging
 import fs2.Stream
-import io.kubernetes.client.openapi.ApiClient
-import io.kubernetes.client.openapi.apis.CoreV1Api
-import io.kubernetes.client.openapi.models.V1Service
-import io.kubernetes.client.util.ClientBuilder
 import org.http4s.Uri
+import skuber._
+import skuber.json.format._
+import skuber.api.client.{EventType, KubernetesClient}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -37,55 +39,44 @@ object ServiceDiscovery extends LazyLogging {
     * Current hard coded polling periods: 2 seconds
     *
     * @param connectionPool to be used for client connections
-    * @param namespace Kubernetes namespace to be queried
-    * @param client Kubernetes java client to be used
     * @param contextShift to be used by the streams
     * @param timer to be used by the streams
-    * @param blockingEC pool used for the blocking operation of the java library
     * @return
     */
-  def resource(connectionPool: ExecutionContext, namespace: String, client: ApiClient = ClientBuilder.cluster.build)(implicit contextShift: ContextShift[IO], timer: Timer[IO], blockingEC: ExecutionContext): Resource[IO, ServiceDiscovery] = {
-    val api = new CoreV1Api(client)
+  def resource(connectionPool: ExecutionContext, k8s: KubernetesClient)(implicit contextShift: ContextShift[IO], timer: Timer[IO], actorSystem: ActorSystem, materializer: Materializer): Resource[IO, ServiceDiscovery] = {
 
-    def fetchServices(namespace: String, api: CoreV1Api)(implicit contextShift: ContextShift[IO], blockingEC: ExecutionContext): IO[List[V1Service]] =
-      contextShift.evalOn(blockingEC)(IO {
-        api.listNamespacedService(namespace, null, null, null, null, null, null, null, null, null)
-          .getItems
-          .asScala
-          .toList
-      }).attempt.flatMap {
-        case Right(services) =>
-          IO.pure(services)
-        case Left(e) =>
-          IO(logger.warn("Failed to communicate with the Kubernetes service: " + e.getMessage))
-          IO.pure(List.empty)
-      }
+    def getHttpServicePortOrDefault(service: Service): String = {
+      for {
+        spec <- service.spec
+        portNumber <- spec.ports.find(_.name == "http-api")
+      } yield portNumber.port.toString
+    }.getOrElse("8080")
 
-    def getInteractionAddresses(currentServices: List[V1Service]): List[Uri] =
+    def getInteractionAddresses(currentServices: List[Service]): List[Uri] =
       currentServices
-        .filter(_.getMetadata.getLabels.getOrDefault("baas-component", "Wrong")
+        .filter(_.metadata.labels.getOrElse("baas-component", "Wrong")
           .equals("remote-interaction"))
-        .map(service => "http://" + service.getMetadata.getName + ":" + service.getSpec.getPorts.asScala.head.getPort)
+        .map(service => "http://" + service.metadata.name + ":" + getHttpServicePortOrDefault(service))
         .map(Uri.unsafeFromString)
 
-    def getEventListenersAddresses(currentServices: List[V1Service]): List[(String, Uri)] =
+    def getEventListenersAddresses(currentServices: List[Service]): List[(String, Uri)] =
       currentServices
-        .filter(_.getMetadata.getLabels.getOrDefault("baas-component", "Wrong")
+        .filter(_.metadata.labels.getOrElse("baas-component", "Wrong")
           .equals("remote-event-listener"))
         .map { service =>
-          val recipe = service.getMetadata.getLabels.getOrDefault("baker-recipe", "All-Recipes")
-          val address = Uri.unsafeFromString("http://" + service.getMetadata.getName + ":" +  + service.getSpec.getPorts.asScala.head.getPort)
+          val recipe = service.metadata.labels.getOrElse("baker-recipe", "All-Recipes")
+          val address = Uri.unsafeFromString("http://" + service.metadata.name + ":" + getHttpServicePortOrDefault(service))
           recipe -> address
         }
 
-    def getBakerEventListenersAddresses(currentServices: List[V1Service]): List[Uri] =
+    def getBakerEventListenersAddresses(currentServices: List[Service]): List[Uri] =
       currentServices
-        .filter(_.getMetadata.getLabels.getOrDefault("baas-component", "Wrong")
+        .filter(_.metadata.labels.getOrElse("baas-component", "Wrong")
           .equals("remote-baker-event-listener"))
-        .map(service => "http://" + service.getMetadata.getName + ":" + service.getSpec.getPorts.asScala.head.getPort)
+        .map(service => "http://" + service.metadata.name + ":" + getHttpServicePortOrDefault(service))
         .map(Uri.unsafeFromString)
 
-    def buildInteractions(currentServices: List[V1Service]): IO[List[InteractionInstance]] =
+    def buildInteractions(currentServices: List[Service]): IO[List[InteractionInstance]] =
       getInteractionAddresses(currentServices)
         .map(RemoteInteractionClient.resource(_, connectionPool))
         .parTraverse[IO, Option[InteractionInstance]](buildInteractionInstance)
@@ -106,35 +97,61 @@ object ServiceDiscovery extends LazyLogging {
         } yield interactionsOpt
       }
 
-    def buildRecipeListeners(currentServices: List[V1Service]): Map[RecipeName, List[RecipeListener]] =
+    def buildRecipeListeners(currentServices: List[Service]): Map[RecipeName, List[RecipeListener]] =
       getEventListenersAddresses(currentServices)
         .map { case (recipe, address) => (recipe, RemoteEventListenerClient.resource(address, connectionPool)) }
         .foldLeft(Map.empty[RecipeName, List[RecipeListener]]) { case (acc, (recipeName, client)) =>
           acc + (recipeName -> (client :: acc.getOrElse(recipeName, List.empty)))
         }
 
-    def buildBakerListeners(currentServices: List[V1Service]): List[BakerListener] =
+    def buildBakerListeners(currentServices: List[Service]): List[BakerListener] =
       getBakerEventListenersAddresses(currentServices)
         .map(RemoteBakerEventListenerClient.resource(_, connectionPool))
 
-    val stream = for {
-      cacheInteractions <- Stream.eval(Ref.of[IO, List[InteractionInstance]](List.empty))
-      cacheRecipeListeners <- Stream.eval(Ref.of[IO, Map[RecipeName, List[RecipeListener]]](Map.empty))
-      cacheBakerListeners <- Stream.eval(Ref.of[IO, List[BakerListener]](List.empty))
-      service = new ServiceDiscovery(cacheInteractions, cacheRecipeListeners, cacheBakerListeners)
-      updateServices = fetchServices(namespace, api)
-        .flatMap { currentServices =>
-          List(
-            buildInteractions(currentServices).flatMap(cacheInteractions.set),
-            cacheRecipeListeners.set(buildRecipeListeners(currentServices)),
-            cacheBakerListeners.set(buildBakerListeners(currentServices))
-          ).parSequence
+    def updateServicesWith(
+      currentServices: Ref[IO, List[Service]],
+      cacheInteractions: Ref[IO, List[InteractionInstance]],
+      cacheRecipeListeners: Ref[IO, Map[RecipeName, List[RecipeListener]]],
+      cacheBakerListeners: Ref[IO, List[BakerListener]]
+    )(event: K8SWatchEvent[Service]): IO[Unit] = {
+      println(Console.MAGENTA + event._type + Console.RESET)
+      println(Console.MAGENTA + event._object + Console.RESET)
+      println()
+      for {
+        services <- event._type match {
+          case EventType.ADDED =>
+            currentServices.updateAndGet(event._object :: _)
+          case EventType.DELETED =>
+            currentServices.updateAndGet(_.filterNot(_ == event._object))
+          case EventType.MODIFIED =>
+            currentServices.updateAndGet(_.map(service => if (service == event._object) event._object else service))
+          case EventType.ERROR =>
+            IO(logger.error(s"Event type ERROR on service watch for service ${event._object}")) *> currentServices.get
         }
-      updater = Stream.fixedRate(5.seconds).evalMap(_ => updateServices)
-      _ <- Stream.eval(updateServices).concurrently(updater)
-    } yield service
+        _ <- List(
+          buildInteractions(services).flatMap(cacheInteractions.set),
+          cacheRecipeListeners.set(buildRecipeListeners(services)),
+          cacheBakerListeners.set(buildBakerListeners(services))
+        ).parSequence
+      } yield ()
+    }
 
-    stream.compile.resource.lastOrError
+    val createServiceDiscovery = for {
+      currentServices <- Ref.of[IO, List[Service]](List.empty)
+      cacheInteractions <- Ref.of[IO, List[InteractionInstance]](List.empty)
+      cacheRecipeListeners <- Ref.of[IO, Map[RecipeName, List[RecipeListener]]](Map.empty)
+      cacheBakerListeners <- Ref.of[IO, List[BakerListener]](List.empty)
+      service = new ServiceDiscovery(cacheInteractions, cacheRecipeListeners, cacheBakerListeners)
+      updateServices = updateServicesWith(currentServices, cacheInteractions, cacheRecipeListeners, cacheBakerListeners)
+      killSwitch <- IO {
+        k8s.watchContinuously[Service]("service")
+          .viaMat(KillSwitches.single)(Keep.right)
+          .toMat(Sink.foreach(updateServices(_).unsafeRunAsyncAndForget()))(Keep.left)
+          .run()
+      }
+    } yield (service, killSwitch)
+
+    Resource.make(createServiceDiscovery)(s => IO(s._2.shutdown())).map(_._1)
   }
 }
 

--- a/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
+++ b/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
@@ -149,7 +149,7 @@ object ServiceDiscovery extends LazyLogging {
   }
 }
 
-final class ServiceDiscovery private(
+case class ServiceDiscovery private(
   cacheInteractions: Ref[IO, List[InteractionInstance]],
   cacheRecipeListeners: Ref[IO, Map[RecipeName, List[RecipeListener]]],
   cacheBakerListeners: Ref[IO, List[BakerListener]]

--- a/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
+++ b/baas-node-state/src/main/scala/com/ing/baker/baas/state/ServiceDiscovery.scala
@@ -86,7 +86,6 @@ object ServiceDiscovery extends LazyLogging {
       resource.use { client =>
         for {
           interface <- client.interface.attempt
-          _ = println(Console.CYAN + interface + Console.RESET)
           interactionsOpt = interface match {
             case Right((name, types)) => Some(InteractionInstance(
               name = name,
@@ -178,9 +177,6 @@ final class ServiceDiscovery private(
       override def addImplementation(interaction: InteractionInstance): Future[Unit] =
         Future.failed(new IllegalStateException("Adding implmentation instances is not supported on a Bakery cluster."))
       override def getImplementation(interaction: InteractionTransition): Future[Option[InteractionInstance]] =
-        cacheInteractions.get.map(_.find(isCompatibleImplementation(interaction, _))).map{ x =>
-          println(Console.MAGENTA + x + Console.RESET)
-          x
-        }.unsafeToFuture()
+        cacheInteractions.get.map(_.find(isCompatibleImplementation(interaction, _))).unsafeToFuture()
     }
 }

--- a/baas-node-state/src/test/resources/mocks/kubeapi_GET_services_watch_event.json
+++ b/baas-node-state/src/test/resources/mocks/kubeapi_GET_services_watch_event.json
@@ -1,0 +1,4 @@
+{
+  "type": "ADDED",
+  "object": "{{items[kubeapi_GET_service.json]}}"
+}

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/kubeapi/Services.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/kubeapi/Services.scala
@@ -7,8 +7,11 @@ case class Services(items: List[Service]) {
   def ++ (services: Service*): Services =
     Services(items ++ services.toList)
 
-  def mock: String = Source
-    .fromResource("mocks/kubeapi_GET_services.json")
-    .mkString
-    .replace("\"{{items[kubeapi_GET_service.json]}}\"", items.map(_.mock).mkString("[ ", ", ", " ]"))
+  def mock: List[String] = {
+    val eventTemplate = Source.fromResource("mocks/kubeapi_GET_services_watch_event.json").mkString
+    items.map { service =>
+      eventTemplate
+        .replace("\"{{items[kubeapi_GET_service.json]}}\"", service.mock)
+    }
+  }
 }

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/mocks/KubeApiServer.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/mocks/KubeApiServer.scala
@@ -1,9 +1,12 @@
 package com.ing.baker.baas.mocks
 
 import cats.effect.IO
+import cats.syntax.apply._
 import com.ing.baker.baas.kubeapi
+import com.ing.baker.baas.kubeapi.{Service, Services}
 import com.ing.baker.baas.recipe.ItemReservationRecipe
 import org.mockserver.integration.ClientAndServer
+import org.mockserver.matchers.Times
 import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.MediaType
@@ -11,17 +14,32 @@ import org.mockserver.model.MediaType
 class KubeApiServer(mock: ClientAndServer) {
 
   def registersRemoteComponents: IO[Unit] =
-    willRespondWith(interactionAndEventListenersServices)
+    respondWithEvents(interactionAndEventListenersServices) *> respondWithEmpty
 
-  private def willRespondWith(services: kubeapi.Services): IO[Unit] = IO {
+  private def respondWithEvents(templates: Services): IO[Unit] = IO {
     mock.when(
       request()
         .withMethod("GET")
         .withPath("/api/v1/namespaces/default/services")
+        .withQueryStringParameter("watch", "true"),
+      Times.exactly(1)
     ).respond(
       response()
         .withStatusCode(200)
-        .withBody(services.mock, MediaType.APPLICATION_JSON)
+        .withBody(templates.mock.mkString("\n"), MediaType.APPLICATION_JSON)
+    )
+  }
+
+  private def respondWithEmpty: IO[Unit] = IO {
+    mock.when(
+      request()
+        .withMethod("GET")
+        .withPath("/api/v1/namespaces/default/services")
+        .withQueryStringParameter("watch", "true")
+    ).respond(
+      response()
+        .withStatusCode(200)
+        .withBody("{}", MediaType.APPLICATION_JSON)
     )
   }
 

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/state/StateNodeSpec.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/state/StateNodeSpec.scala
@@ -316,6 +316,7 @@ class StateNodeSpec extends BakeryFunSpec with Matchers {
             allowAddingRecipeWithoutRequiringInstances = true))(system))
 
       _ <- Resource.liftF(serviceDiscovery.plugBakerEventListeners(baker))
+      // Liveness checks on event discovery
       _ <- Resource.liftF(eventually(serviceDiscovery.cacheRecipeListeners.get.map(data =>
         assert(data.get(ItemReservationRecipe.compiledRecipe.name).map(_.length).contains(1)))))
       _ <- Resource.liftF(eventually(serviceDiscovery.cacheInteractions.get.map(data =>

--- a/build.sbt
+++ b/build.sbt
@@ -290,7 +290,7 @@ lazy val `baas-node-state` = project.in(file("baas-node-state"))
       akkaManagementHttp,
       akkaClusterBoostrap,
       akkaDiscoveryKube,
-      kubernetesJavaClient,
+      skuber,
       http4s,
       http4sDsl,
       http4sServer

--- a/build.sbt
+++ b/build.sbt
@@ -297,6 +297,7 @@ lazy val `baas-node-state` = project.in(file("baas-node-state"))
     ) ++ testDeps(
       slf4jApi,
       slf4jSimple,
+      logback,
       scalaTest,
       mockServer,
       circe,
@@ -330,7 +331,8 @@ lazy val `baas-node-interaction` = project.in(file("baas-node-interaction"))
       http4sDsl,
       http4sServer
     ) ++ testDeps(
-      scalaTest
+      scalaTest,
+      logback
     )
   )
   .dependsOn(`baas-protocol-interaction-scheduling`, `baker-interface`)
@@ -346,7 +348,8 @@ lazy val `baas-node-event-listener` = project.in(file("baas-node-event-listener"
       http4sDsl,
       http4sServer
     ) ++ testDeps(
-      scalaTest
+      scalaTest,
+      logback
     ))
   .dependsOn(`baas-protocol-recipe-event-publishing`, `baker-interface`)
 
@@ -361,7 +364,8 @@ lazy val `baas-node-baker-event-listener` = project.in(file("baas-node-baker-eve
       http4sDsl,
       http4sServer
     ) ++ testDeps(
-      scalaTest
+      scalaTest,
+      logback
     )
   )
   .dependsOn(`baas-protocol-baker-event-publishing`, `baker-interface`)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,8 @@ object Dependencies {
   val kamon =                     "io.kamon"                   %% "kamon-bundle"                       % "2.0.0"
   val kamonAkka =                 "io.kamon"                   %% "kamon-akka"                         % "2.0.0"
   val kamonPrometheus =           "io.kamon"                   %% "kamon-prometheus"                   % "2.0.0"
+
+  val skuber =                    "io.skuber"                  %% "skuber"                             % "2.4.0"
   val http4s =                    "org.http4s"                 %% "http4s-core"                        % http4sVersion
   val http4sDsl =                 "org.http4s"                 %% "http4s-dsl"                         % http4sVersion
   val http4sServer =              "org.http4s"                 %% "http4s-blaze-server"                % http4sVersion
@@ -84,7 +86,6 @@ object Dependencies {
   val typeSafeConfig =            "com.typesafe"               % "config"                              % "1.4.0"
 
   val objenisis =                 "org.objenesis"              %  "objenesis"                          % "3.1"
-  val kubernetesJavaClient =      "io.kubernetes"              %  "client-java"                        % "7.0.0"
   val jodaTime =                  "joda-time"                  %  "joda-time"                          % "2.10.5"
   val slf4jApi =                  "org.slf4j"                  %  "slf4j-api"                          % "1.7.30"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,8 +88,8 @@ object Dependencies {
   val objenisis =                 "org.objenesis"              %  "objenesis"                          % "3.1"
   val jodaTime =                  "joda-time"                  %  "joda-time"                          % "2.10.5"
   val slf4jApi =                  "org.slf4j"                  %  "slf4j-api"                          % "1.7.30"
-
   val slf4jSimple =               "org.slf4j"                  % "slf4j-simple"                        % "1.7.30"
+  val logback =                   "ch.qos.logback"             % "logback-classic"                     % "1.2.3"
   val scalaCheck =                "org.scalacheck"             %% "scalacheck"                         % "1.13.5"
 
   val scalaLogging =              "com.typesafe.scala-logging" %% "scala-logging"                      % "3.9.2"

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/BakerInquireSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/BakerInquireSpec.scala
@@ -45,7 +45,6 @@ class BakerInquireSpec extends BakerRuntimeTestBase {
       for {
         (baker, recipeId) <- setupBakerWithRecipe("returnHealthRecipe", false)
         recipeInformation <- baker.getRecipe(recipeId)
-        _ = println(recipeInformation)
         _ = assert(recipeInformation.compiledRecipe.recipeId == recipeId && recipeInformation.errors.isEmpty)
       } yield succeed
     }


### PR DESCRIPTION
1. Removed the java api library in favor of Skuber
2. The ServiceDiscovery.scala in the state node project now uses an akka stream to update local cache
3. The constructor (ServiceDiscovery.resource) still uses cats.effect.Resource to create and cleanup the stream
4. There is an improvement on the functional tests, liveness checks for the discovery of the services were added before each test (on the StateNodeSpec.contextBuilder function)