### PR TITLE
Great dependency bump

### DIFF
--- a/baas-node-interaction/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
+++ b/baas-node-interaction/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
@@ -4,12 +4,13 @@ import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.syntax.apply._
 import org.scalactic.source
 import org.scalatest.compatible.Assertion
-import org.scalatest.{ConfigMap, FutureOutcome, Tag, fixture}
+import org.scalatest.funspec.FixtureAsyncFunSpecLike
+import org.scalatest.{ConfigMap, FutureOutcome, Tag}
 
 import scala.concurrent.duration._
 
 /** Abstracts the common test practices across the Bakery project. */
-abstract class BakeryFunSpec extends fixture.AsyncFunSpecLike {
+abstract class BakeryFunSpec extends FixtureAsyncFunSpecLike {
 
   implicit val contextShift: ContextShift[IO] =
     IO.contextShift(executionContext)

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/mocks/Utils.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/mocks/Utils.scala
@@ -6,7 +6,7 @@ import com.ing.baker.runtime.serialization.{Encryption, ProtoMap}
 
 object Utils {
 
-  private type ProtoMessage[A] = scalapb.GeneratedMessage with scalapb.Message[A]
+  private type ProtoMessage[A] = scalapb.GeneratedMessage
 
   def serialize[A, P <: ProtoMessage[P]](message: A)(implicit mapping: ProtoMap[A, P]): Array[Byte] =
     mapping.toByteArray(message)

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/state/StateNodeSpec.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/state/StateNodeSpec.scala
@@ -19,7 +19,8 @@ import com.ing.baker.runtime.common.{BakerException, SensoryEventStatus}
 import com.ing.baker.runtime.scaladsl.{Baker, EventInstance, InteractionInstance}
 import com.typesafe.config.ConfigFactory
 import org.mockserver.integration.ClientAndServer
-import org.scalatest.{ConfigMap, Matchers}
+import org.scalatest.ConfigMap
+import org.scalatest.matchers.should.Matchers
 import skuber.api.client.KubernetesClient
 
 import scala.concurrent.Future

--- a/baas-node-state/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
+++ b/baas-node-state/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
@@ -4,12 +4,13 @@ import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.syntax.apply._
 import org.scalactic.source
 import org.scalatest.compatible.Assertion
-import org.scalatest.{ConfigMap, FutureOutcome, Tag, fixture}
+import org.scalatest.funspec.FixtureAsyncFunSpecLike
+import org.scalatest.{ConfigMap, FutureOutcome, Tag}
 
 import scala.concurrent.duration._
 
 /** Abstracts the common test practices across the Bakery project. */
-abstract class BakeryFunSpec extends fixture.AsyncFunSpecLike {
+abstract class BakeryFunSpec extends FixtureAsyncFunSpecLike {
 
   implicit val contextShift: ContextShift[IO] =
     IO.contextShift(executionContext)

--- a/baas-protocol-baker/src/main/protobuf/baas.proto
+++ b/baas-protocol-baker/src/main/protobuf/baas.proto
@@ -6,6 +6,7 @@ import "common.proto";
 option java_package = "com.ing.baker.baas.protocol.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 message BaaSRemoteFailure {

--- a/baas-protocol-baker/src/main/scala/com/ing/baker/baas/protocol/BakeryHttp.scala
+++ b/baas-protocol-baker/src/main/scala/com/ing/baker/baas/protocol/BakeryHttp.scala
@@ -13,7 +13,7 @@ object BakeryHttp {
 
   object ProtoEntityEncoders {
 
-    type ProtoMessage[A] = scalapb.GeneratedMessage with scalapb.Message[A]
+    type ProtoMessage[A] = scalapb.GeneratedMessage
 
     implicit def protoDecoder[A, P <: ProtoMessage[P]](implicit protoMap: ProtoMap[A, P]): EntityDecoder[IO, A] =
       EntityDecoder.decodeBy(MediaType.application.`octet-stream`)(collectBinary[IO]).map(_.toArray)

--- a/baas-protocol-interaction-scheduling/src/main/protobuf/interaction_schedulling.proto
+++ b/baas-protocol-interaction-scheduling/src/main/protobuf/interaction_schedulling.proto
@@ -6,6 +6,7 @@ import "common.proto";
 option java_package = "com.ing.baker.baas.protocol.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 message ExecuteInstance {

--- a/baas-protocol-interaction-scheduling/src/main/scala/com/ing/baker/baas/interaction/BakeryHttp.scala
+++ b/baas-protocol-interaction-scheduling/src/main/scala/com/ing/baker/baas/interaction/BakeryHttp.scala
@@ -13,7 +13,7 @@ object BakeryHttp {
 
   object ProtoEntityEncoders {
 
-    type ProtoMessage[A] = scalapb.GeneratedMessage with scalapb.Message[A]
+    type ProtoMessage[A] = scalapb.GeneratedMessage
 
     implicit def protoDecoder[A, P <: ProtoMessage[P]](implicit protoMap: ProtoMap[A, P]): EntityDecoder[IO, A] =
       EntityDecoder.decodeBy(MediaType.application.`octet-stream`)(collectBinary[IO]).map(_.toArray)

--- a/baas-smoke-tests/src/test/scala/com/ing/baker/baas/smoke/BakeryControllerSmokeTests.scala
+++ b/baas-smoke-tests/src/test/scala/com/ing/baker/baas/smoke/BakeryControllerSmokeTests.scala
@@ -4,7 +4,8 @@ import cats.effect.{IO, Resource}
 import com.ing.baker.baas.smoke
 import com.ing.baker.baas.smoke.k8s.{DefinitionFile, Pod}
 import com.ing.baker.baas.testing.BakeryFunSpec
-import org.scalatest.{ConfigMap, Matchers}
+import org.scalatest.ConfigMap
+import org.scalatest.matchers.should.Matchers
 
 import scala.sys.process._
 

--- a/baas-smoke-tests/src/test/scala/com/ing/baker/baas/smoke/BakerySmokeTests.scala
+++ b/baas-smoke-tests/src/test/scala/com/ing/baker/baas/smoke/BakerySmokeTests.scala
@@ -5,7 +5,8 @@ import com.ing.baker.baas.smoke.k8s.{DefinitionFile, Pod}
 import com.ing.baker.baas.testing.BakeryFunSpec
 import io.circe.parser._
 import org.http4s.Uri
-import org.scalatest.{ConfigMap, Matchers}
+import org.scalatest.ConfigMap
+import org.scalatest.matchers.should.Matchers
 import webshop.webservice.OrderStatus
 
 class BakerySmokeTests extends BakeryFunSpec with Matchers {

--- a/baas-smoke-tests/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
+++ b/baas-smoke-tests/src/test/scala/com/ing/baker/baas/testing/BakeryFunSpec.scala
@@ -2,15 +2,16 @@ package com.ing.baker.baas.testing
 
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.syntax.apply._
+import com.ing.baker.baas.smoke.printGreen
 import org.scalactic.source
 import org.scalatest.compatible.Assertion
-import org.scalatest.{ConfigMap, FutureOutcome, Tag, fixture}
-import com.ing.baker.baas.smoke.printGreen
+import org.scalatest.funspec.FixtureAsyncFunSpecLike
+import org.scalatest.{ConfigMap, FutureOutcome, Tag}
 
 import scala.concurrent.duration._
 
 /** Abstracts the common test practices across the Bakery project. */
-abstract class BakeryFunSpec extends fixture.AsyncFunSpecLike {
+abstract class BakeryFunSpec extends FixtureAsyncFunSpecLike {
 
   implicit val contextShift: ContextShift[IO] =
     IO.contextShift(executionContext)

--- a/baker-interface/src/main/protobuf/common.proto
+++ b/baker-interface/src/main/protobuf/common.proto
@@ -5,6 +5,7 @@ import "scalapb/scalapb.proto";
 option java_package = "com.ing.baker.runtime.akka.actor.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 // other

--- a/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/ProtoMap.scala
+++ b/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/ProtoMap.scala
@@ -9,7 +9,7 @@ import scalapb.GeneratedMessageCompanion
 
 import scala.util.{Success, Try}
 
-trait ProtoMap[A, P <: scalapb.GeneratedMessage with scalapb.Message[P]] {
+trait ProtoMap[A, P <: scalapb.GeneratedMessage] {
 
   def companion: GeneratedMessageCompanion[P]
 
@@ -27,9 +27,9 @@ trait ProtoMap[A, P <: scalapb.GeneratedMessage with scalapb.Message[P]] {
 
 object ProtoMap {
 
-  def ctxToProto[A, P <: scalapb.GeneratedMessage with scalapb.Message[P]](a: A)(implicit ev: ProtoMap[A, P]): P = ev.toProto(a)
+  def ctxToProto[A, P <: scalapb.GeneratedMessage ](a: A)(implicit ev: ProtoMap[A, P]): P = ev.toProto(a)
 
-  def ctxFromProto[A, P <: scalapb.GeneratedMessage with scalapb.Message[P]](proto: P)(implicit ev: ProtoMap[A, P]): Try[A] = ev.fromProto(proto)
+  def ctxFromProto[A, P <: scalapb.GeneratedMessage ](proto: P)(implicit ev: ProtoMap[A, P]): Try[A] = ev.fromProto(proto)
 
   def versioned[A](a: Option[A], name: String): Try[A] =
     Try(a.getOrElse(throw new IllegalStateException(s"Missing field '$name' from protobuf message, probably we received a different version of the message")))
@@ -87,7 +87,7 @@ object ProtoMap {
   implicit val processEventResult: ProtoMap[SensoryEventResult, protobuf.SensoryEventResult] =
     new SensoryEventResultMapping
 
-  def identityProtoMap[A <: scalapb.GeneratedMessage with scalapb.Message[A]](companion0: GeneratedMessageCompanion[A]): ProtoMap[A, A] =
+  def identityProtoMap[A <: scalapb.GeneratedMessage](companion0: GeneratedMessageCompanion[A]): ProtoMap[A, A] =
     new ProtoMap[A, A] {
 
       override def companion: GeneratedMessageCompanion[A] = companion0

--- a/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/CompiledRecipeMapping.scala
+++ b/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/CompiledRecipeMapping.scala
@@ -115,7 +115,7 @@ class CompiledRecipeMapping extends ProtoMap[il.CompiledRecipe, protobuf.Compile
       val edge = e.label.asInstanceOf[il.petrinet.Edge]
       val from = nodeList.indexOf(e.source.value)
       val to = nodeList.indexOf(e.target.value)
-      protobuf.Edge(Option(from), Option(to), Option(e.weight), edge.eventAllowed)
+      protobuf.Edge(Option(from), Option(to), Option(e.weight.toLong), edge.eventAllowed)
     }
   }
 

--- a/baker-interface/src/test/scala/com/ing/baker/baas/utils/BakeryFunSpec.scala
+++ b/baker-interface/src/test/scala/com/ing/baker/baas/utils/BakeryFunSpec.scala
@@ -1,15 +1,16 @@
 package com.ing.baker.baas.utils
 
-import cats.syntax.apply._
 import cats.effect.{ContextShift, IO, Resource, Timer}
-import org.scalatest.compatible.Assertion
-import org.scalatest.{ConfigMap, FutureOutcome, Tag, fixture}
+import cats.syntax.apply._
 import org.scalactic.source
+import org.scalatest.compatible.Assertion
+import org.scalatest.funspec.FixtureAsyncFunSpecLike
+import org.scalatest.{ConfigMap, FutureOutcome, Tag}
 
 import scala.concurrent.duration._
 
 /** Abstracts the common test practices across the Bakery project. */
-abstract class BakeryFunSpec extends fixture.AsyncFunSpecLike {
+abstract class BakeryFunSpec extends FixtureAsyncFunSpecLike {
 
   implicit val contextShift: ContextShift[IO] =
     IO.contextShift(executionContext)

--- a/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/EventJsonEncodersSpec.scala
+++ b/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/EventJsonEncodersSpec.scala
@@ -10,10 +10,11 @@ import com.ing.baker.runtime.serialization.EventJsonEncoders._
 import com.ing.baker.types
 import com.ing.baker.types.{ListValue, PrimitiveValue}
 import io.circe.syntax._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import scalax.collection.immutable.Graph
 
-class EventJsonEncodersSpec extends FunSpec with Matchers {
+class EventJsonEncodersSpec extends AnyFunSpec with Matchers {
   describe("EventCodecs") {
     it("should encode RejectReason enum") {
       RejectReason.values().foreach(

--- a/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/EventJsonToScalaDslDecodersSpec.scala
+++ b/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/EventJsonToScalaDslDecodersSpec.scala
@@ -4,12 +4,11 @@ import com.ing.baker.runtime.scaladsl.EventInstance
 import com.ing.baker.runtime.serialization.EventJsonToScalaDslDecoders._
 import com.ing.baker.types._
 import io.circe.parser.decode
-import io.circe.syntax._
-import org.scalatest.{FunSpec, Matchers}
-import com.ing.baker.runtime.serialization.EventJsonEncoders._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class EventJsonToScalaDslDecodersSpec extends FunSpec with Matchers {
+class EventJsonToScalaDslDecodersSpec extends AnyFunSpec with Matchers {
   describe("EventJsonToScalaDslDecoders") {
     it("should decode value") {
       val nullValue = decode[Value]("""{"typ":0}""")
@@ -49,7 +48,7 @@ class EventJsonToScalaDslDecodersSpec extends FunSpec with Matchers {
       shortValue.right.get shouldEqual PrimitiveValue(600.toShort)
 
       val longValue = decode[Value]("""{"typ":3,"styp":"java.lang.Long","val":"123456789012345"}""")
-      longValue.right.get shouldEqual PrimitiveValue(123456789012345l)
+      longValue.right.get shouldEqual PrimitiveValue(123456789012345L)
     }
 
     it("decodes EventInstance") {

--- a/bakertypes/src/test/scala/com/ing/baker/types/modules/JavaModulesSpec.scala
+++ b/bakertypes/src/test/scala/com/ing/baker/types/modules/JavaModulesSpec.scala
@@ -8,7 +8,8 @@ import com.ing.baker.types.Converters._
 import com.ing.baker.types.ConvertersTestData.TestEnum
 import com.ing.baker.types.ConvertersTestData.TestEnum.{ValueA, ValueB, ValueC}
 import com.ing.baker.types._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.JavaConverters._
 
@@ -22,7 +23,7 @@ class PersonPojo(val name: String, val age: Int) {
   }
 }
 
-class JavaModulesSpec extends WordSpecLike with Matchers {
+class JavaModulesSpec extends AnyWordSpecLike with Matchers {
 
   val recordPerson = RecordValue(Map("name" -> PrimitiveValue("john"), "age" -> PrimitiveValue(42)))
 

--- a/bakertypes/src/test/scala/com/ing/baker/types/modules/JodaTimeModuleSpec.scala
+++ b/bakertypes/src/test/scala/com/ing/baker/types/modules/JodaTimeModuleSpec.scala
@@ -5,11 +5,11 @@ import com.ing.baker.types.Converters
 import org.joda.time.{DateTime, LocalDate, LocalDateTime}
 import org.scalacheck.Gen
 import org.scalacheck.Test.Parameters.defaultVerbose
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.scalacheck.Checkers
 
-
-class JodaTimeModuleSpec extends WordSpecLike with Matchers with Checkers {
+class JodaTimeModuleSpec extends AnyWordSpecLike with Matchers with Checkers {
 
   private val minSuccessfulTests = 100
 

--- a/bakertypes/src/test/scala/com/ing/baker/types/modules/PrimitiveModuleSpec.scala
+++ b/bakertypes/src/test/scala/com/ing/baker/types/modules/PrimitiveModuleSpec.scala
@@ -7,10 +7,11 @@ import com.ing.baker.types.Converters
 import com.ing.baker.types.Converters.readJavaType
 import com.ing.baker.types.modules.PrimitiveModuleSpec._
 import org.scalacheck.Gen
-import org.scalacheck.Prop.{BooleanOperators, forAll}
+import org.scalacheck.Prop.{propBoolean, forAll}
 import org.scalacheck.Test.Parameters.defaultVerbose
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.scalacheck.Checkers
-import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -34,7 +35,7 @@ object PrimitiveModuleSpec {
   val byteArrayGen: Gen[Array[Byte]] = Gen.listOf(intGen.map(_.toByte)).map(_.toArray)
 }
 
-class PrimitiveModuleSpec extends WordSpecLike with Matchers with Checkers {
+class PrimitiveModuleSpec extends AnyWordSpecLike with Matchers with Checkers {
 
   "The primivite module" should {
 

--- a/bakertypes/src/test/scala/com/ing/baker/types/modules/ScalaModulesSpec.scala
+++ b/bakertypes/src/test/scala/com/ing/baker/types/modules/ScalaModulesSpec.scala
@@ -3,10 +3,11 @@ package com.ing.baker.types.modules
 import com.ing.baker.types
 import com.ing.baker.types.Converters.{readJavaType, toJava, toValue}
 import com.ing.baker.types._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.scalacheck.Checkers
 
-class ScalaModulesSpec extends WordSpecLike with Matchers with Checkers {
+class ScalaModulesSpec extends AnyWordSpecLike with Matchers with Checkers {
 
   private val listValue123 = ListValue(List(PrimitiveValue(1), PrimitiveValue(2), PrimitiveValue(3)))
 

--- a/bakertypes/src/test/scala/com/ing/baker/types/modules/package.scala
+++ b/bakertypes/src/test/scala/com/ing/baker/types/modules/package.scala
@@ -1,6 +1,6 @@
 package com.ing.baker.types
 
-import org.scalacheck.Prop.{BooleanOperators, forAll}
+import org.scalacheck.Prop.{propBoolean, forAll}
 import org.scalacheck.{Gen, Prop}
 
 import scala.reflect.runtime.universe.TypeTag

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val bakertypes = project.in(file("bakertypes"))
       typeSafeConfig,
       scalaReflect(scalaVersion.value),
       scalaLogging
-    ) ++ testDeps(scalaTest, scalaCheck, scalaCheck)
+    ) ++ testDeps(scalaTest, scalaCheck, scalaCheckPlus)
   )
 
 lazy val intermediateLanguage = project.in(file("intermediate-language"))
@@ -95,7 +95,7 @@ lazy val intermediateLanguage = project.in(file("intermediate-language"))
       scalaGraphDot,
       typeSafeConfig,
       scalaLogging
-    ) ++ testDeps(scalaTest, scalaCheck)
+    ) ++ testDeps(scalaTest, scalaCheck, scalaCheckPlus)
   ).dependsOn(bakertypes)
 
 lazy val `baker-interface` = project.in(file("baker-interface"))
@@ -156,6 +156,8 @@ lazy val runtime = project.in(file("runtime"))
         junitInterface,
         scalaTest,
         scalaCheck,
+        scalaCheckPlus,
+        scalaCheckPlusMockito,
         mockito)
         ++ providedDeps(findbugs)
   )
@@ -205,6 +207,7 @@ lazy val recipeDsl = project.in(file("recipe-dsl"))
         testDeps(
           scalaTest,
           scalaCheck,
+          scalaCheckPlus,
           junitInterface,
           slf4jApi
         )
@@ -497,7 +500,8 @@ lazy val `baas-interaction-example-make-payment-and-ship-items` = project.in(fil
         catsEffect
       ) ++ testDeps(
         scalaTest,
-        scalaCheck
+        scalaCheck,
+        scalaCheckPlus
       )
   )
   .dependsOn(`baas-node-interaction`)

--- a/compiler/src/test/scala/com/ing/baker/compiler/RecipeCompilerSpec.scala
+++ b/compiler/src/test/scala/com/ing/baker/compiler/RecipeCompilerSpec.scala
@@ -9,12 +9,13 @@ import com.ing.baker.recipe.common.InteractionFailureStrategy
 import com.ing.baker.recipe.common.InteractionFailureStrategy.RetryWithIncrementalBackoff.UntilDeadline
 import com.ing.baker.recipe.scaladsl._
 import com.ing.baker.types._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class RecipeCompilerSpec extends WordSpecLike with Matchers {
+class RecipeCompilerSpec extends AnyWordSpecLike with Matchers {
 
   "The recipe compiler" should {
 

--- a/intermediate-language/src/test/scala/com/ing/baker/il/HashcodeGenerationSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/il/HashcodeGenerationSpec.scala
@@ -1,10 +1,10 @@
 package com.ing.baker.il
 
 import org.scalacheck.{Gen, Prop, Test}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 
-class HashcodeGenerationSpec extends FunSuite with Checkers {
+class HashcodeGenerationSpec extends AnyFunSuite with Checkers {
   test("sha256 hash function") {
     val prop = Prop.forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
       (s1: String, s2: String) => {

--- a/intermediate-language/src/test/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoffSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoffSpec.scala
@@ -1,11 +1,12 @@
 package com.ing.baker.il.failurestrategy
 
 import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome.{BlockTransition, RetryWithDelay}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 
-class RetryWithIncrementalBackoffSpec extends WordSpecLike with Matchers {
+class RetryWithIncrementalBackoffSpec extends AnyWordSpecLike with Matchers {
 
   "The RetryWithIncrementalBackoff" should {
     "return RetryWithDelay with the correct time until the next retry" in {

--- a/intermediate-language/src/test/scala/com/ing/baker/il/petrinet/IntermediateTransitionSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/il/petrinet/IntermediateTransitionSpec.scala
@@ -1,8 +1,10 @@
 package com.ing.baker.il.petrinet
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class IntermediateTransitionSpec extends FunSuite with Matchers {
+
+class IntermediateTransitionSpec extends AnyFunSuite with Matchers {
 
   test("id is computed") {
     IntermediateTransition("testTransition").id shouldBe -401713565417492236l

--- a/intermediate-language/src/test/scala/com/ing/baker/il/petrinet/MissingEventTransitionSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/il/petrinet/MissingEventTransitionSpec.scala
@@ -1,8 +1,10 @@
 package com.ing.baker.il.petrinet
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class MissingEventTransitionSpec extends FunSuite with Matchers {
+
+class MissingEventTransitionSpec extends AnyFunSuite with Matchers {
 
   test("id is computed") {
     MissingEventTransition("testTransition").id shouldBe -3991477867259255746l

--- a/intermediate-language/src/test/scala/com/ing/baker/petrinet/api/MarkingSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/petrinet/api/MarkingSpec.scala
@@ -1,9 +1,9 @@
 package com.ing.baker.petrinet.api
 
-import org.scalatest.Matchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class MarkingSpec extends WordSpec {
+class MarkingSpec extends AnyWordSpec {
 
   case class Person(name: String, age: Int)
 

--- a/intermediate-language/src/test/scala/com/ing/baker/petrinet/api/PetriNetAnalysisSpec.scala
+++ b/intermediate-language/src/test/scala/com/ing/baker/petrinet/api/PetriNetAnalysisSpec.scala
@@ -1,7 +1,8 @@
 package com.ing.baker.petrinet.api
 
 import com.ing.baker.petrinet.api.DSL._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import scalax.collection.edge.WLDiEdge
 import scalax.collection.immutable.Graph
 
@@ -68,7 +69,7 @@ object DSL {
   }
 }
 
-class PetriNetAnalysisSpec extends WordSpec with Matchers {
+class PetriNetAnalysisSpec extends AnyWordSpec with Matchers {
 
   "The PetriNetAnalysis class" should {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val akkaVersion = "2.5.29"
   
-  val http4sVersion = "0.21.2"
+  val http4sVersion = "0.21.3"
   val circeVersion = "0.13.0"
 
   val jvmV = "1.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
       .exclude("com.typesafe.akka", "akka-stream")
 
   val scalaJava8Compat =          "org.scala-lang.modules"     %% "scala-java8-compat"                 % "0.9.1"
-  val scalaTest =                 "org.scalatest"              %% "scalatest"                          % "3.0.8"
+  val scalaTest =                 "org.scalatest"              %% "scalatest"                          % "3.1.1"
   val mockito =                   "org.mockito"                %  "mockito-all"                        % "1.10.19"
   val mockServer =                "org.mock-server"            %  "mockserver-netty"                   % "5.10"
   val junitInterface =            "com.novocode"               %  "junit-interface"                    % "0.11"
@@ -50,9 +50,9 @@ object Dependencies {
 
   val ficusConfig =               "com.iheart"                 %% "ficus"                              % "1.4.7"
 
-  val scalaGraph  =               "org.scala-graph"            %% "graph-core"                         % "1.11.5"
-  val scalaGraphDot =             "org.scala-graph"            %% "graph-dot"                          % "1.11.5"
-  val graphvizJava =              "guru.nidi"                  %  "graphviz-java"                      % "0.8.10"
+  val scalaGraph  =               "org.scala-graph"            %% "graph-core"                         % "1.13.1"
+  val scalaGraphDot =             "org.scala-graph"            %% "graph-dot"                          % "1.13.0"
+  val graphvizJava =              "guru.nidi"                  %  "graphviz-java"                      % "0.15.1"
 
   val kamon =                     "io.kamon"                   %% "kamon-bundle"                       % "2.0.0"
   val kamonAkka =                 "io.kamon"                   %% "kamon-akka"                         % "2.0.0"
@@ -94,8 +94,9 @@ object Dependencies {
   val slf4jApi =                  "org.slf4j"                  %  "slf4j-api"                          % "1.7.30"
   val slf4jSimple =               "org.slf4j"                  % "slf4j-simple"                        % "1.7.30"
   val logback =                   "ch.qos.logback"             % "logback-classic"                     % "1.2.3"
-  val scalaCheck =                "org.scalacheck"             %% "scalacheck"                         % "1.13.5"
-
+  val scalaCheck =                "org.scalacheck"             %% "scalacheck"                         % "1.14.3"
+  val scalaCheckPlus =            "org.scalatestplus"          %% "scalatestplus-scalacheck"           % "3.1.0.0-RC2"
+  val scalaCheckPlusMockito =     "org.scalatestplus"          %% "scalatestplus-mockito"              % "1.0.0-M2"
   val scalaLogging =              "com.typesafe.scala-logging" %% "scala-logging"                      % "3.9.2"
 
   def scopeDeps(scope: String, modules: Seq[ModuleID]) =  modules.map(m => m % scope)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.6.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.6.2")
 
 addSbtPlugin("org.vaslabs.kube" % "sbt-kubeyml" % "0.3.3")
 

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.2"

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/HashingSpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/HashingSpec.scala
@@ -6,10 +6,10 @@ import com.ing.baker.types._
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Test.Parameters.defaultVerbose
 import org.scalacheck.{Arbitrary, Gen, Test}
-import org.scalatest.FunSuiteLike
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 
-class HashingSpec extends FunSuiteLike with Checkers {
+class HashingSpec extends AnyFunSuite with Checkers {
 
   val config: Test.Parameters =
     defaultVerbose.withMinSuccessfulTests(minSuccessfulTests = 1000)

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/InteractionFailureStrategySpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/common/InteractionFailureStrategySpec.scala
@@ -2,12 +2,13 @@ package com.ing.baker.recipe.common
 
 import com.ing.baker.recipe.common.InteractionFailureStrategy.RetryWithIncrementalBackoff.{UntilDeadline, UntilMaximumRetries}
 import com.ing.baker.recipe.common.InteractionFailureStrategy._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class InteractionFailureStrategySpec extends WordSpecLike with Matchers {
+class InteractionFailureStrategySpec extends AnyWordSpecLike with Matchers {
 
   "RetryWithIncrementalBackoff " should {
 

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/CommonMacrosSpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/CommonMacrosSpec.scala
@@ -1,9 +1,10 @@
 package com.ing.baker.recipe.scaladsl
 
 import com.ing.baker.types
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class CommonMacrosSpec extends WordSpecLike with Matchers {
+class CommonMacrosSpec extends AnyWordSpecLike with Matchers {
 
   "an Ingredient" when {
     "constructed using macro" should {

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/IngredientSpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/IngredientSpec.scala
@@ -2,9 +2,10 @@ package com.ing.baker.recipe.scaladsl
 
 import com.ing.baker.types
 import com.ing.baker.types._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class IngredientSpec extends WordSpecLike with Matchers {
+class IngredientSpec extends AnyWordSpecLike with Matchers {
   "an Ingredient" when {
 
     "constructed" should {

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/InteractionDescriptorSpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/InteractionDescriptorSpec.scala
@@ -1,7 +1,8 @@
 package com.ing.baker.recipe.scaladsl
 
 import com.ing.baker.recipe.scaladsl.InteractionDescriptorSpec._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 object InteractionDescriptorSpec {
   val customerName = Ingredient[String]("customerName")
@@ -15,7 +16,7 @@ object InteractionDescriptorSpec {
   val anOtherEvent = Event("anOtherEvent")
 }
 
-class InteractionDescriptorSpec extends WordSpecLike with Matchers {
+class InteractionDescriptorSpec extends AnyWordSpecLike with Matchers {
   "an InteractionDescriptor" when {
 
     "requiredEvents called" should {

--- a/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/InteractionSpec.scala
+++ b/recipe-dsl/src/test/scala/com/ing/baker/recipe/scaladsl/InteractionSpec.scala
@@ -1,9 +1,10 @@
 package com.ing.baker.recipe.scaladsl
 
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 
-class InteractionSpec extends WordSpecLike with Matchers {
+class InteractionSpec extends AnyWordSpecLike with Matchers {
   "an Interaction" when {
     "calling the Equals method" should {
       "return true if same interaction instance" in {

--- a/runtime/src/main/protobuf/process_index.proto
+++ b/runtime/src/main/protobuf/process_index.proto
@@ -6,6 +6,7 @@ import "common.proto";
 option java_package = "com.ing.baker.runtime.akka.actor.process_index.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 // Akka

--- a/runtime/src/main/protobuf/process_instance.proto
+++ b/runtime/src/main/protobuf/process_instance.proto
@@ -6,6 +6,7 @@ import "scalapb/scalapb.proto";
 option java_package = "com.ing.baker.runtime.akka.actor.process_instance.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 // Events

--- a/runtime/src/main/protobuf/recipe_manager.proto
+++ b/runtime/src/main/protobuf/recipe_manager.proto
@@ -6,6 +6,7 @@ import "scalapb/scalapb.proto";
 option java_package = "com.ing.baker.runtime.akka.actor.recipe_manager.protobuf";
 option (scalapb.options) = {
     flat_package: true
+    preserve_unknown_fields: false
 };
 
 // PERSISTED MESSAGES

--- a/runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/TypedProtobufSerializer.scala
+++ b/runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/TypedProtobufSerializer.scala
@@ -17,13 +17,13 @@ object TypedProtobufSerializer {
 
   class RegisterFor[A <: AnyRef](classTag: ClassTag[A]) {
 
-    def register[P <: scalapb.GeneratedMessage with scalapb.Message[P]](implicit protoMap: ProtoMap[A, P]): BinarySerializable =
+    def register[P <: scalapb.GeneratedMessage ](implicit protoMap: ProtoMap[A, P]): BinarySerializable =
       register[P](None)
 
-    def register[P <: scalapb.GeneratedMessage with scalapb.Message[P]](overrideName: String)(implicit protoMap: ProtoMap[A, P]): BinarySerializable =
+    def register[P <: scalapb.GeneratedMessage ](overrideName: String)(implicit protoMap: ProtoMap[A, P]): BinarySerializable =
       register[P](Some(overrideName))
 
-    def register[P <: scalapb.GeneratedMessage with scalapb.Message[P]](overrideName: Option[String])(implicit protoMap: ProtoMap[A, P]): BinarySerializable = {
+    def register[P <: scalapb.GeneratedMessage ](overrideName: Option[String])(implicit protoMap: ProtoMap[A, P]): BinarySerializable = {
       new BinarySerializable {
 
         override type Type = A

--- a/runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
+++ b/runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
@@ -16,7 +16,9 @@ import com.ing.baker.types.{Converters, Value}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
@@ -109,7 +111,7 @@ trait BakerRuntimeTestBase
   def writeRecipeToSVGFile(recipe: CompiledRecipe) = {
     import guru.nidi.graphviz.engine.{Format, Graphviz}
     import guru.nidi.graphviz.parse.Parser
-    val g = Parser.read(recipe.getRecipeVisualization)
+    val g = (new Parser()).read(recipe.getRecipeVisualization)
     Graphviz.fromGraph(g).render(Format.SVG).toFile(Paths.get(recipe.name).toFile)
   }
 

--- a/runtime/src/test/scala/com/ing/baker/il/RecipeVisualizerSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/il/RecipeVisualizerSpec.scala
@@ -2,12 +2,13 @@ package com.ing.baker.il
 
 import com.ing.baker.compiler.RecipeCompiler
 import com.ing.baker.recipe.TestRecipe._
-import com.ing.baker.recipe.scaladsl.{Recipe, _}
-import org.scalatest.{Matchers, WordSpecLike}
+import com.ing.baker.recipe.scaladsl.Recipe
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.language.postfixOps
 
-class RecipeVisualizerSpec extends WordSpecLike with Matchers {
+class RecipeVisualizerSpec extends AnyWordSpecLike with Matchers {
 
   "The Recipe visualisation module" should {
 

--- a/runtime/src/test/scala/com/ing/baker/pbt/RecipePropertiesSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/pbt/RecipePropertiesSpec.scala
@@ -9,13 +9,13 @@ import com.ing.baker.recipe.{common, scaladsl}
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Test.Parameters.defaultVerbose
 import org.scalacheck._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 
 import scala.annotation.tailrec
 import scala.util.Random
 
-class RecipePropertiesSpec extends FunSuite with Checkers {
+class RecipePropertiesSpec extends AnyFunSuite with Checkers {
 
   import RecipePropertiesSpec._
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/AkkaTestBase.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/AkkaTestBase.scala
@@ -2,10 +2,11 @@ package com.ing.baker.runtime.akka.actor
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class AkkaTestBase(actorSystemName: String = "testActorSystem") extends TestKit(ActorSystem(actorSystemName))
-    with WordSpecLike
+    with AnyWordSpecLike
     with ImplicitSender
     with BeforeAndAfterAll {
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/UtilSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/UtilSpec.scala
@@ -3,7 +3,7 @@ package com.ing.baker.runtime.akka.actor
 import scala.collection.immutable.List
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class UtilSpec extends AkkaTestBase("UtilSpec") {
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexSpec.scala
@@ -22,9 +22,10 @@ import com.ing.baker.types.Value
 import com.typesafe.config.{Config, ConfigFactory}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.Eventually
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 import scalax.collection.immutable.Graph
 
@@ -43,7 +44,7 @@ object ProcessIndexSpec {
 //noinspection TypeAnnotation
 class ProcessIndexSpec extends TestKit(ActorSystem("ProcessIndexSpec", ProcessIndexSpec.config))
   with ImplicitSender
-  with WordSpecLike
+  with AnyWordSpecLike
   with Matchers
   with BeforeAndAfterAll
   with BeforeAndAfter

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/SensoryEventResponseHandlerSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/SensoryEventResponseHandlerSpec.scala
@@ -10,12 +10,12 @@ import com.ing.baker.runtime.akka.actor.process_instance.ProcessInstanceProtocol
 import com.ing.baker.runtime.common.SensoryEventStatus
 import com.ing.baker.runtime.scaladsl.{ EventInstance, SensoryEventResult }
 import com.ing.baker.types.{ PrimitiveValue, Value }
-import org.scalatest.Matchers._
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class SensoryEventResponseHandlerSpec extends TestKit(ActorSystem("SensoryEventResponseHandlerSpec")) with WordSpecLike {
+class SensoryEventResponseHandlerSpec extends TestKit(ActorSystem("SensoryEventResponseHandlerSpec")) with AnyWordSpecLike {
 
   implicit val ec: ExecutionContext = system.dispatcher
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceEventSourcingSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceEventSourcingSpec.scala
@@ -17,7 +17,7 @@ import java.util.UUID
 
 import com.ing.baker.runtime.serialization.Encryption.NoEncryption
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceSpec.scala
@@ -24,7 +24,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Milliseconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
@@ -633,7 +633,7 @@ class ProcessInstanceSpec extends AkkaTestBase("ProcessInstanceSpec") with Scala
 
       expectMsgPF() { case TransitionFired(_, 1, _, _, _, _, _) ⇒ }
 
-      import org.scalatest.concurrent.Timeouts._
+      import org.scalatest.concurrent.TimeLimits._
 
       failAfter(Span(dilatedMillis(1000), Milliseconds)) {
 

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/serialization/EncryptionPropertiesSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/serialization/EncryptionPropertiesSpec.scala
@@ -1,13 +1,13 @@
 package com.ing.baker.runtime.akka.actor.serialization
 
+import com.ing.baker.runtime.serialization.Encryption._
 import org.scalacheck.Gen._
 import org.scalacheck.Prop.forAll
 import org.scalacheck._
-import org.scalatest.FunSuite
-import com.ing.baker.runtime.serialization.Encryption._
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 
-class EncryptionPropertiesSpec extends FunSuite with Checkers {
+class EncryptionPropertiesSpec extends AnyFunSuite with Checkers {
 
   val desEncryptionGen: Gen[DESEncryption] = for {
     keyChars ← Gen.listOfN(8, alphaChar)

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/serialization/SerializationSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/actor/serialization/SerializationSpec.scala
@@ -20,7 +20,6 @@ import com.ing.baker.runtime.akka.actor.recipe_manager.{RecipeManager, RecipeMan
 import com.ing.baker.runtime.common.SensoryEventStatus
 import com.ing.baker.runtime.scaladsl.{EventInstance, EventMoment, RecipeInstanceState, SensoryEventResult}
 import com.ing.baker.runtime.serialization.Encryption.{AESEncryption, NoEncryption}
-import com.ing.baker.runtime.serialization.ProtoMap
 import com.ing.baker.runtime.serialization.ProtoMap.{ctxFromProto, ctxToProto}
 import com.ing.baker.types.modules.PrimitiveModuleSpec._
 import com.ing.baker.types.{Value, _}
@@ -28,14 +27,14 @@ import com.ing.baker.{AllTypeRecipe, types}
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Test.Parameters.defaultVerbose
 import org.scalacheck._
-import org.scalatest.FunSuiteLike
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.Success
 
-class SerializationSpec extends TestKit(ActorSystem("BakerProtobufSerializerSpec")) with FunSuiteLike with Checkers {
+class SerializationSpec extends TestKit(ActorSystem("BakerProtobufSerializerSpec")) with AnyFunSuiteLike with Checkers {
 
   val serializer: BakerTypedProtobufSerializer =
     SerializationExtension

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/internal/InteractionManagerSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/internal/InteractionManagerSpec.scala
@@ -6,7 +6,8 @@ import com.ing.baker.runtime.scaladsl.InteractionInstance
 import com.ing.baker.types
 import com.ing.baker.types.Type
 import org.mockito.Mockito.when
-import org.scalatest.{AsyncWordSpecLike, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 
 class InteractionManagerLocalSpec extends AsyncWordSpecLike with Matchers with MockitoSugar {

--- a/runtime/src/test/scala/com/ing/baker/runtime/akka/internal/RecipeRuntimeSpec.scala
+++ b/runtime/src/test/scala/com/ing/baker/runtime/akka/internal/RecipeRuntimeSpec.scala
@@ -8,10 +8,11 @@ import com.ing.baker.runtime.scaladsl.RecipeInstanceState
 import com.ing.baker.types.Value
 import com.ing.baker.{il, types}
 import org.mockito.Mockito._
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 
-class RecipeRuntimeSpec extends WordSpecLike with Matchers with MockitoSugar {
+class RecipeRuntimeSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
   "The recipe runtime" should {
     "provide a ProcessID ingredient to an interaction if required" in {
       val processId = UUID.randomUUID().toString

--- a/split-brain-resolver/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
+++ b/split-brain-resolver/src/test/scala/akka/remote/testkit/STMultiNodeSpec.scala
@@ -5,16 +5,17 @@
 //#example
 package akka.remote.testkit
 
-import scala.language.implicitConversions
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
-import org.scalatest.Matchers
+import scala.language.implicitConversions
 
 /**
   * Hooks up MultiNodeSpec with ScalaTest
   */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-  with WordSpecLike with Matchers with BeforeAndAfterAll { self: MultiNodeSpec ⇒
+  with AnyWordSpecLike with Matchers with BeforeAndAfterAll { self: MultiNodeSpec ⇒
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 


### PR DESCRIPTION
Bundle of all scala steward version bumps (only akka not touched) and required code changes for deprecation etc.

- Update sbt-native-packager to 1.6.2 
- Update compilerplugin, scalapb-runtime to 0.10.2 
- Update graphviz-java to 0.15.1 
- Update scalatest to 3.1.1 
- Update graph-dot to 1.13.0 
- Update graph-core to 1.13.1 
- Update scalacheck to 1.14.3 
- Update http4s-... to 0.21.3