### PR TITLE
azure pipeline OS build

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -4,6 +4,17 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
+
+variables:
+  IVY_HOME: $(Pipeline.Workspace)/.ivy2
+
 steps:
-  - script: sbt clean coverage test coverageReport
+  - task: Cache@2
+    inputs:
+      key: 'ivy | "$(Agent.OS)"'
+      restoreKeys: ivy
+      path: $(IVY_HOME)
+    displayName: Ivy build cache
+
+  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'

--- a/azure.yaml
+++ b/azure.yaml
@@ -9,12 +9,11 @@ variables:
   IVY_HOME: $(Pipeline.Workspace)/.ivy2
 
 steps:
-  - task: Cache@2
+  - task: CacheBeta@1
     inputs:
-      key: 'ivy | "$(Agent.OS)"'
-      restoreKeys: ivy
-      path: $(IVY_HOME)
-    displayName: Ivy build cache
+      key: 'ivy'
+      path: '$(IVY_HOME)'
+      displayName: Ivy build cache
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'

--- a/azure.yaml
+++ b/azure.yaml
@@ -24,7 +24,6 @@ steps:
       key: 'ivy_home'
       path: '$(IVY_HOME)'
 
-
   - task: Bash@3
     displayName: Generate artifacts' version
     inputs:

--- a/azure.yaml
+++ b/azure.yaml
@@ -28,12 +28,11 @@ steps:
       targetType: 'inline'
       script: printf "realm=pkgs.dev.azure.com\nhost=pkgs.dev.azure.com\nuser=${FEEDUSER}\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     env:
-      FEEDPASSWORD: $(feedPassword)
+      FEEDPASSWORD: $(feedPassword) # secrets extracted explicitly, other vars - from the group
 
-  - script: sbt package #clean coverage test coverageReport
+  - script: sbt clean coverage test coverageReport
     displayName: 'Running sbt'
 
   - script: sbt aetherDeploy
     displayName: 'Publishing results'
     condition: succeeded()
-

--- a/azure.yaml
+++ b/azure.yaml
@@ -23,14 +23,12 @@ steps:
       script: bash ./set-version.sh
 
   - task: Bash@3
-    displayName: 'Update credentials'
+    displayName: 'Prepare publishing credentials'
     inputs:
       targetType: 'inline'
-      script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
+      script: printf "realm=pkgs.dev.azure.com\nhost=pkgs.dev.azure.com\nuser=${FEEDUSER}\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     env:
       FEEDPASSWORD: $(feedPassword)
-
-  - script: cat ~/.credentials
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} package #clean coverage test coverageReport
     displayName: 'Running sbt'
@@ -38,6 +36,6 @@ steps:
   - script: du -h ~
     displayName: 'Disk use'
 
-  - script: sbt publish
+  - script: sbt aetherDeploy
     displayName: 'Publishing results'
     condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -5,14 +5,29 @@ pool:
   vmImage: 'ubuntu-latest'
 
 variables:
-  IVY_HOME: $(Pipeline.Workspace)/.ivy2
+  - group: BakeryOSSFeedCredentials
+  - name: IVY_HOME
+    value: $(Pipeline.Workspace)/.ivy2
 
 steps:
   - task: CacheBeta@1
-    displayName: Ivy build cache
+    displayName: Ivy cache
     inputs:
       key: 'ivy'
       path: '$(IVY_HOME)'
 
+  - task: Bash@3
+    displayName: Generate artifacts' version
+    inputs:
+      targetType: 'inline'
+      script: bash ./set-version.sh
+        cat ./version.sbt
+
+  - displayName: Update credentials
+    script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.sbt/.credentials
+
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'
+
+  - script: sbt publish
+    condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -11,7 +11,7 @@ variables:
 
 steps:
   - task: CacheBeta@1
-    displayName: Ivy cache
+    displayName: Package resolver cache
     inputs:
       key: 'cache'
       path: '$(CACHE)'
@@ -30,7 +30,7 @@ steps:
     env:
       FEEDPASSWORD: $(feedPassword)
 
-  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} package #clean coverage test coverageReport
+  - script: sbt package #clean coverage test coverageReport
     displayName: 'Running sbt'
 
   - script: sbt aetherDeploy

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,8 @@ variables:
   - group: BakeryOSSFeedCredentials
   - name: CACHE
     value: $(HOME)/.cache
+  - name: IVY_HOME
+    value: $(Pipeline.Workspace)/.ivy2
 
 steps:
   - task: CacheBeta@1
@@ -15,6 +17,13 @@ steps:
     inputs:
       key: 'cache'
       path: '$(CACHE)'
+
+  - task: CacheBeta@1
+    displayName: Ivy resolver cache
+    inputs:
+      key: 'ivy_home'
+      path: '$(IVY_HOME)'
+
 
   - task: Bash@3
     displayName: Generate artifacts' version
@@ -30,9 +39,9 @@ steps:
     env:
       FEEDPASSWORD: $(feedPassword) # secrets extracted explicitly, other vars - from the group
 
-  - script: sbt clean coverage test coverageReport
+  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'
 
-  - script: sbt aetherDeploy
+  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} aetherDeploy
     displayName: 'Publishing results'
     condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -7,7 +7,7 @@ pool:
 variables:
   - group: BakeryOSSFeedCredentials
   - name: CACHE
-    value: ~/.cache
+    value: $(HOME)/.cache
 
 steps:
   - task: CacheBeta@1

--- a/azure.yaml
+++ b/azure.yaml
@@ -39,9 +39,5 @@ steps:
     env:
       FEEDPASSWORD: $(feedPassword) # secrets extracted explicitly, other vars - from the group
 
-  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
+  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport aetherDeploy
     displayName: 'Running sbt'
-
-  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} aetherDeploy
-    displayName: 'Publishing results'
-    condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -33,9 +33,6 @@ steps:
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} package #clean coverage test coverageReport
     displayName: 'Running sbt'
 
-  - script: du -h ~
-    displayName: 'Disk use'
-
   - script: sbt aetherDeploy
     displayName: 'Publishing results'
     condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -20,7 +20,7 @@ steps:
     displayName: Generate artifacts' version
     inputs:
       targetType: 'inline'
-      script: ./set-version.sh
+      script: bash ./set-version.sh
 
   - task: Bash@3
     displayName: 'Update credentials'

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,5 @@
 trigger:
   - master
-  - feature*
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure.yaml
+++ b/azure.yaml
@@ -23,11 +23,12 @@ steps:
       script: bash ./set-version.sh
         cat ./version.sbt
 
-  - displayName: Update credentials
-    script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.sbt/.credentials
+  - script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.sbt/.credentials
+    displayName: Update credentials
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'
 
   - script: sbt publish
+    displayName: 'Publishing results'
     condition: succeeded()

--- a/azure.yaml
+++ b/azure.yaml
@@ -36,3 +36,4 @@ steps:
   - script: sbt aetherDeploy
     displayName: 'Publishing results'
     condition: succeeded()
+

--- a/azure.yaml
+++ b/azure.yaml
@@ -23,11 +23,10 @@ steps:
       script: ./set-version.sh
 
   - task: Bash@3
-      displayName: Generate artifacts' version
-      inputs:
-        targetType: 'inline'
-        script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     displayName: 'Update credentials'
+    inputs:
+      targetType: 'inline'
+      script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     env:
       FEEDPASSWORD: $(feedPassword)
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,0 +1,9 @@
+trigger:
+  - master
+  - feature*
+
+pool:
+  vmImage: 'ubuntu-latest'
+steps:
+  - script: sbt clean coverage test coverageReport
+    displayName: 'Running sbt'

--- a/azure.yaml
+++ b/azure.yaml
@@ -20,10 +20,16 @@ steps:
     displayName: Generate artifacts' version
     inputs:
       targetType: 'inline'
-      script: bash ./set-version.sh
+      script: ./set-version.sh
 
-  - script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
+  - task: Bash@3
+      displayName: Generate artifacts' version
+      inputs:
+        targetType: 'inline'
+        script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     displayName: 'Update credentials'
+    env:
+      FEEDPASSWORD: $(feedPassword)
 
   - script: cat ~/.credentials
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -23,7 +23,7 @@ steps:
       script: bash ./set-version.sh
         cat ./version.sbt
 
-  - script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.sbt/.credentials
+  - script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.credentials
     displayName: Update credentials
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport

--- a/azure.yaml
+++ b/azure.yaml
@@ -21,13 +21,16 @@ steps:
     inputs:
       targetType: 'inline'
       script: bash ./set-version.sh
-        cat ./version.sbt
 
   - script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.credentials
-    displayName: Update credentials
+        cat ~/.credentials
+    displayName: 'Update credentials'
 
-  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
+  - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} package #clean coverage test coverageReport
     displayName: 'Running sbt'
+
+  - script: du -h ~
+    displayName: 'Disk use'
 
   - script: sbt publish
     displayName: 'Publishing results'

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,10 +10,10 @@ variables:
 
 steps:
   - task: CacheBeta@1
+    displayName: Ivy build cache
     inputs:
       key: 'ivy'
       path: '$(IVY_HOME)'
-      displayName: Ivy build cache
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} clean coverage test coverageReport
     displayName: 'Running sbt'

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,15 +6,15 @@ pool:
 
 variables:
   - group: BakeryOSSFeedCredentials
-  - name: IVY_HOME
-    value: $(Pipeline.Workspace)/.ivy2
+  - name: CACHE
+    value: ~/.cache
 
 steps:
   - task: CacheBeta@1
     displayName: Ivy cache
     inputs:
-      key: 'ivy'
-      path: '$(IVY_HOME)'
+      key: 'cache'
+      path: '$(CACHE)'
 
   - task: Bash@3
     displayName: Generate artifacts' version
@@ -22,9 +22,10 @@ steps:
       targetType: 'inline'
       script: bash ./set-version.sh
 
-  - script: printf "realm=BakeryOSSFeed\\nhost=${feedUrl}\\nuser=${feedUser}\\npassword=${feedPassword}\n" > ~/.credentials
-        cat ~/.credentials
+  - script: printf "realm=BakeryOSSFeed\\nhost=${FEEDURL}\\nuser=${FEEDUSER}\\npassword=${FEEDPASSWORD}\n" > ~/.credentials
     displayName: 'Update credentials'
+
+  - script: cat ~/.credentials
 
   - script: sbt -Divy.home=${IVY_HOME} -Dsbt.ivy.home=${IVY_HOME} package #clean coverage test coverageReport
     displayName: 'Running sbt'

--- a/build.sbt
+++ b/build.sbt
@@ -530,7 +530,7 @@ lazy val `baas-smoke-tests` = project.in(file("baas-smoke-tests"))
 
 lazy val `sbt-baas-docker-generate` = project.in(file("sbt-baas-docker-generate"))
   .settings(defaultModuleSettings)
-  .settings(noPublishSettings) // docker plugin can't be published to azure feed
+  .settings(noPublishSettings) // docker plugin can't be published, at least not to azure feed
   .settings(
     // workaround to let plugin be used in the same project without publishing it
     sourceGenerators in Compile += Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val noPublishSettings = Seq(
   publishArtifact := false
 )
 
-lazy val defaultModuleSettings = commonSettings ++ dependencyOverrideSettings ++ SonatypePublish.settings
+lazy val defaultModuleSettings = commonSettings ++ dependencyOverrideSettings ++ Publish.settings
 
 lazy val scalaPBSettings = Seq(PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value))
 
@@ -351,7 +351,6 @@ lazy val `bakery-controller` = project.in(file("bakery-controller"))
 
 lazy val baker = project.in(file("."))
   .settings(defaultModuleSettings)
-  .settings(noPublishSettings)
   .aggregate(bakertypes, runtime, recipeCompiler, recipeDsl, intermediateLanguage, splitBrainResolver,
     `baas-node-client`, `baas-node-state`, `baas-node-interaction`, `sbt-baas-docker-generate`, `baas-protocol-interaction-scheduling`,
     `baker-interface`)

--- a/build.sbt
+++ b/build.sbt
@@ -531,6 +531,8 @@ lazy val `baas-smoke-tests` = project.in(file("baas-smoke-tests"))
 lazy val `sbt-baas-docker-generate` = project.in(file("sbt-baas-docker-generate"))
   .settings(defaultModuleSettings)
   .settings(
+    publish := {} // do not publish to remote repo
+  ).settings(
     // workaround to let plugin be used in the same project without publishing it
     sourceGenerators in Compile += Def.task {
       val file = (sourceManaged in Compile).value / "baas" / "sbt" / "BuildInteractionDockerImageSBTPlugin.scala"

--- a/build.sbt
+++ b/build.sbt
@@ -530,7 +530,7 @@ lazy val `baas-smoke-tests` = project.in(file("baas-smoke-tests"))
 
 lazy val `sbt-baas-docker-generate` = project.in(file("sbt-baas-docker-generate"))
   .settings(defaultModuleSettings)
-  .settings(noPublishSettings)
+  .settings(noPublishSettings) // docker plugin can't be published to azure feed
   .settings(
     // workaround to let plugin be used in the same project without publishing it
     sourceGenerators in Compile += Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ lazy val baker = project.in(file("."))
   .settings(defaultModuleSettings)
   .aggregate(bakertypes, runtime, recipeCompiler, recipeDsl, intermediateLanguage, splitBrainResolver,
     `baas-node-client`, `baas-node-state`, `baas-node-interaction`, `sbt-baas-docker-generate`, `baas-protocol-interaction-scheduling`,
-    `baker-interface`)
+    `baker-interface`, `bakery-controller`)
 
 lazy val `baker-example` = project
   .in(file("examples/baker-example"))

--- a/build.sbt
+++ b/build.sbt
@@ -351,7 +351,8 @@ lazy val `bakery-controller` = project.in(file("bakery-controller"))
 lazy val baker = project.in(file("."))
   .settings(defaultModuleSettings)
   .aggregate(bakertypes, runtime, recipeCompiler, recipeDsl, intermediateLanguage, splitBrainResolver,
-    `baas-node-client`, `baas-node-state`, `baas-node-interaction`, `sbt-baas-docker-generate`, `baas-protocol-interaction-scheduling`,
+    `baas-node-client`, `baas-node-state`, `baas-node-interaction`, `baas-protocol-interaction-scheduling`, `baas-protocol-baker`,
+    `sbt-baas-docker-generate`,
     `baker-interface`, `bakery-controller`)
 
 lazy val `baker-example` = project

--- a/build.sbt
+++ b/build.sbt
@@ -530,9 +530,8 @@ lazy val `baas-smoke-tests` = project.in(file("baas-smoke-tests"))
 
 lazy val `sbt-baas-docker-generate` = project.in(file("sbt-baas-docker-generate"))
   .settings(defaultModuleSettings)
+  .settings(noPublishSettings)
   .settings(
-    publish := {} // do not publish to remote repo
-  ).settings(
     // workaround to let plugin be used in the same project without publishing it
     sourceGenerators in Compile += Def.task {
       val file = (sourceManaged in Compile).value / "baas" / "sbt" / "BuildInteractionDockerImageSBTPlugin.scala"

--- a/build.sbt
+++ b/build.sbt
@@ -261,7 +261,7 @@ lazy val `baas-node-client` = project.in(file("baas-node-client"))
 
 lazy val `baas-node-state` = project.in(file("baas-node-state"))
   .enablePlugins(JavaAppPackaging)
-  .settings(commonSettings)
+  .settings(commonSettings ++ Publish.settings)
   .settings(
     moduleName := "baas-node-state",
     scalacOptions ++= Seq(

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -4,7 +4,14 @@ import sbtrelease.ReleasePlugin.autoImport._
 import sbtrelease.ReleaseStateTransformations._
 import xerial.sbt.Sonatype.SonatypeKeys._
 
-object SonatypePublish {
+object Publish {
+
+  lazy val settings = if (sys.env.get("feedUrl").isDefined) AzureFeed else Sonatype
+
+  val AzureFeed = Seq(
+    credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
+    publishTo := Some("BakeryOSSFeed" at sys.env.getOrElse("feedUrl", ""))
+  )
 
   protected def isSnapshot(s: String) = s.trim endsWith "SNAPSHOT"
 
@@ -12,7 +19,7 @@ object SonatypePublish {
   protected val ossSnapshots = "Sonatype OSS Snapshots" at nexus + "content/repositories/snapshots/"
   protected val ossStaging = "Sonatype OSS Staging" at nexus + "service/local/staging/deploy/maven2/"
 
-  val settings = Seq(
+  val Sonatype = Seq(
     sonatypeProfileName := "com.ing",
     licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT")),
     homepage := Some(url("https://github.com/ing-bank/baker")),

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -9,7 +9,7 @@ object Publish {
   lazy val settings = if (sys.env.get("feedUrl").isDefined) AzureFeed else Sonatype
 
   val AzureFeed = Seq(
-    credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
+    credentials += Credentials(Path.userHome / ".credentials"),
     publishTo := Some("BakeryOSSFeed" at sys.env.getOrElse("feedUrl", ""))
   )
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -8,9 +8,13 @@ object Publish {
 
   lazy val settings = if (sys.env.get("FEEDURL").isDefined) AzureFeed else Sonatype
 
+  import aether.AetherKeys._
+
   val AzureFeed = Seq(
     credentials += Credentials(Path.userHome / ".credentials"),
-    publishTo := Some("BakeryOSSFeed" at sys.env.getOrElse("FEEDURL", ""))
+    publishTo := Some("pkgs.dev.azure.com" at sys.env.getOrElse("FEEDURL", "")),
+    publishMavenStyle := true,
+    logLevel in aetherDeploy := Level.Info
   )
 
   protected def isSnapshot(s: String) = s.trim endsWith "SNAPSHOT"

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -6,11 +6,11 @@ import xerial.sbt.Sonatype.SonatypeKeys._
 
 object Publish {
 
-  lazy val settings = if (sys.env.get("feedUrl").isDefined) AzureFeed else Sonatype
+  lazy val settings = if (sys.env.get("FEEDURL").isDefined) AzureFeed else Sonatype
 
   val AzureFeed = Seq(
     credentials += Credentials(Path.userHome / ".credentials"),
-    publishTo := Some("BakeryOSSFeed" at sys.env.getOrElse("feedUrl", ""))
+    publishTo := Some("BakeryOSSFeed" at sys.env.getOrElse("FEEDURL", ""))
   )
 
   protected def isSnapshot(s: String) = s.trim endsWith "SNAPSHOT"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.0")
 
 addSbtPlugin("org.vaslabs.kube" % "sbt-kubeyml" % "0.3.4")
 
+addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.23.0")
+
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.30"

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bump this manually whenever breaking change occurs
-SEM_VERSION=3.0.2
+SEM_VERSION=$(cat version.sbt | sed 's/version in ThisBuild := \"\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\).*/\1.\2.\3/')
 
 DATE=$(date +"%Y%m%d_%H%M%S")
 COMMIT=$( git log --pretty=format:'%h' -n 1)

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# bump this manually whenever change occurs
+SEM_VERSION=3.0.2
+
+BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p' | sed -e 's#/#_#g')
+DATE=$(date +"%Y%m%d_%H%M%S")
+COMMIT=$( git log --pretty=format:'%h' -n 1)
+
+if [ "$BRANCH" = "master" ]; then BRANCH=""; else BRANCH="-${BRANCH}"; fi
+
+VERSION="${SEM_VERSION}${BRANCH}-${DATE}-${COMMIT}"
+
+echo "version in ThisBuild := \"${VERSION}\"" > version.sbt

--- a/set-version.sh
+++ b/set-version.sh
@@ -11,5 +11,3 @@ VERSION="${SEM_VERSION}-${DATE}-${COMMIT}"
 echo "version in ThisBuild := \"${VERSION}\"" > ./version.sbt
 
 cat ./version.sbt
-
-set

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bump this manually whenever breaking change occurs
-SEM_VERSION=3.0
+SEM_VERSION=3.0.2
 
 DATE=$(date +"%Y%m%d_%H%M%S")
 COMMIT=$( git log --pretty=format:'%h' -n 1)

--- a/set-version.sh
+++ b/set-version.sh
@@ -3,12 +3,13 @@
 # bump this manually whenever change occurs
 SEM_VERSION=3.0.2
 
-BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p' | sed -e 's#/#_#g')
 DATE=$(date +"%Y%m%d_%H%M%S")
 COMMIT=$( git log --pretty=format:'%h' -n 1)
 
-if [ "$BRANCH" = "master" ]; then BRANCH=""; else BRANCH="-${BRANCH}"; fi
+VERSION="${SEM_VERSION}-${DATE}-${COMMIT}"
 
-VERSION="${SEM_VERSION}${BRANCH}-${DATE}-${COMMIT}"
+echo "version in ThisBuild := \"${VERSION}\"" > ./version.sbt
 
-echo "version in ThisBuild := \"${VERSION}\"" > version.sbt
+cat ./version.sbt
+
+set

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-# bump this manually whenever change occurs
-SEM_VERSION=3.0.2
+# bump this manually whenever breaking change occurs
+SEM_VERSION=3.0
 
 DATE=$(date +"%Y%m%d_%H%M%S")
 COMMIT=$( git log --pretty=format:'%h' -n 1)
-
 VERSION="${SEM_VERSION}-${DATE}-${COMMIT}"
 
 echo "version in ThisBuild := \"${VERSION}\"" > ./version.sbt
-
-cat ./version.sbt

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,2 @@
-version in ThisBuild := "3.0.2-20200406_172337-1ef18b0c"
+// replaced by pipeline builds via set-version.sh
+version in ThisBuild := "3.0.2-local"

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 // replaced by pipeline builds via set-version.sh
-version in ThisBuild := "3.0.2-local"
+version in ThisBuild := "3.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.2-SNAPSHOT"
+version in ThisBuild := "3.0.2-feature_bakeryoss-20200406.140008-d0a9d44f"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.2-feature_bakeryoss-20200406.140008-d0a9d44f"
+version in ThisBuild := "3.0.2-20200406_172337-1ef18b0c"

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,1 @@
-// replaced by pipeline builds via set-version.sh
-version in ThisBuild := "3.0.2-SNAPSHOT"
+version in ThisBuild := "3.0.2-20200409_234647-46e9a1d4"


### PR DESCRIPTION
- Azure pipeline to build OS Baker(y)
- aether plugin since default sbt deploy doesn't work with Azure
- Publish to either Sonatype or Azure feed (injected via env vars)
- Resolver cache
- CI/CD-friendly versioning (no -SNAPSHOTs anymore)

Unrelated:
- sbt version bump