### PR TITLE
bundled dependency version bump + configurable API client URL

### DIFF
--- a/azure-build.yaml
+++ b/azure-build.yaml
@@ -14,6 +14,8 @@ variables:
     value: $(HOME)/.cache
   - name: IVY_HOME
     value: $(Pipeline.Workspace)/.ivy2
+  - name: CACHE_RUN_ID
+    value: "201009"
 
 steps:
   - task: Bash@3
@@ -42,13 +44,13 @@ steps:
   - task: CacheBeta@1
     displayName: Package resolver cache
     inputs:
-      key: 'cache'
+      key: cache_$(CACHE_RUN_ID)
       path: '$(CACHE)'
 
   - task: CacheBeta@1
     displayName: Ivy resolver cache
     inputs:
-      key: 'ivy_home'
+      key: ivy_home_$(CACHE_RUN_ID)
       path: '$(IVY_HOME)'
 
   - task: Bash@3

--- a/bakery/baker-client/src/main/scala/com/ing/bakery/common/FailoverState.scala
+++ b/bakery/baker-client/src/main/scala/com/ing/bakery/common/FailoverState.scala
@@ -15,5 +15,5 @@ sealed class FailoverState(hosts: IndexedSeq[Uri]) {
 
   def failed(): Int = currentPosition.getAndUpdate((operand: Int) => if (operand + 1 < size) operand + 1 else 0)
 
-  def host: Uri = hosts(currentPosition.get())
+  def uri: Uri = hosts(currentPosition.get())
 }

--- a/bakery/baker-client/src/main/scala/com/ing/bakery/javadsl/BakerClient.scala
+++ b/bakery/baker-client/src/main/scala/com/ing/bakery/javadsl/BakerClient.scala
@@ -21,33 +21,35 @@ object BakerClient {
   type Filter = java.util.function.Function[Request[IO], Request[IO]]
 
   def build(hostname: String,
+            apiUrlString: String,
             filters: JList[Filter],
             tlsConfig: Optional[TLSConfig]): CompletableFuture[JavaBaker] = {
-      build(Collections.singletonList(hostname), filters, tlsConfig)
+    build(Collections.singletonList(hostname), apiUrlString, filters, tlsConfig)
   }
 
-  def build(hostname: String, filters: JList[Filter]): CompletableFuture[JavaBaker] = {
-    build(hostname, filters, Optional.empty[TLSConfig]())
+  def build(hostname: String, apiUrlString: String, filters: JList[Filter]): CompletableFuture[JavaBaker] = {
+    build(hostname, apiUrlString, filters, Optional.empty[TLSConfig]())
   }
 
-  def build(hostname: String, tlsConfig: Optional[TLSConfig]): CompletableFuture[JavaBaker] = {
-    build(hostname, Collections.emptyList[Filter](), tlsConfig)
+  def build(hostname: String, apiUrlString: String, tlsConfig: Optional[TLSConfig]): CompletableFuture[JavaBaker] = {
+    build(hostname, apiUrlString, Collections.emptyList[Filter](), tlsConfig)
   }
 
-  def build(hostname: String): CompletableFuture[JavaBaker] = {
-    build(hostname, Collections.emptyList[Filter](), Optional.empty[TLSConfig]())
+  def build(hostname: String, apiUrlString: String): CompletableFuture[JavaBaker] = {
+    build(hostname, apiUrlString, Collections.emptyList[Filter](), Optional.empty[TLSConfig]())
   }
 
   //TODO add resource cleanup possibility.
   /**
-    * Return async result with JavaBaker instance, using hosts, filters and tlsConfig
-    *
-    * @param hosts     List of hosts for baker cluster (more than 1 hosts is supported for multi-dc option)
-    * @param filters   Http filters
-    * @param tlsConfig TLS context for connection
-    * @return JavaBaker
-    */
+   * Return async result with JavaBaker instance, using hosts, filters and tlsConfig
+   *
+   * @param hosts     List of hosts for baker cluster (more than 1 hosts is supported for multi-dc option)
+   * @param filters   Http filters
+   * @param tlsConfig TLS context for connection
+   * @return JavaBaker
+   */
   def build(hosts: JList[String],
+            apiUrlPrefix: String,
             filters: JList[Filter],
             tlsConfig: Optional[TLSConfig]): CompletableFuture[JavaBaker] = {
 
@@ -66,6 +68,7 @@ object BakerClient {
         new scaladsl.BakerClient(
           client = client,
           hosts = hosts.asScala.map(Uri.unsafeFromString).toIndexedSeq,
+          apiUrlPrefix = apiUrlPrefix,
           filters = filters.asScala.map(_.asScala))
       }
       .allocated

--- a/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
+++ b/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
@@ -84,6 +84,7 @@ final case class ResponseError(status: Int, msg: String)
 final class BakerClient(
                          client: Client[IO],
                          hosts: IndexedSeq[Uri],
+                         apiUrlPrefix: String,
                          filters: Seq[Request[IO] => Request[IO]] = Seq.empty)
                        (implicit ec: ExecutionContext) extends ScalaBaker with LazyLogging {
 

--- a/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
+++ b/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
@@ -38,6 +38,7 @@ object BakerClient {
     */
 
   def resourceBalanced(hosts: IndexedSeq[Uri],
+                       apiUrlPrefix: String,
                        executionContext: ExecutionContext,
                        filters: Seq[Request[IO] => Request[IO]] = Seq.empty,
                        tlsConfig: Option[TLSConfig] = None)
@@ -47,7 +48,7 @@ object BakerClient {
     BlazeClientBuilder[IO](executionContext, tlsConfig.map(_.loadSSLContext))
       .resource
       .map(client => {
-        new BakerClient(client, hosts, filters)
+        new BakerClient(client, hosts, apiUrlPrefix, filters)
       })
   }
 
@@ -64,16 +65,17 @@ object BakerClient {
     * @return IO Resource for BakerClient
     */
   def resource(host: Uri,
+               apiUrlPrefix: String,
                executionContext: ExecutionContext,
                filters: Seq[Request[IO] => Request[IO]] = Seq.empty,
                tlsConfig: Option[TLSConfig] = None)
               (implicit cs: ContextShift[IO], timer: Timer[IO]): Resource[IO, BakerClient] =
-    resourceBalanced(IndexedSeq(host), executionContext, filters, tlsConfig)(cs, timer)
+    resourceBalanced(IndexedSeq(host), apiUrlPrefix, executionContext, filters, tlsConfig)(cs, timer)
 
 
-  def apply(client: Client[IO], host: Uri, filters: Seq[Request[IO] => Request[IO]])
+  def apply(client: Client[IO], host: Uri, apiUrlPrefix: String, filters: Seq[Request[IO] => Request[IO]])
            (implicit ec: ExecutionContext): BakerClient =
-    new BakerClient(client, IndexedSeq(host), filters)(ec)
+    new BakerClient(client, IndexedSeq(host), apiUrlPrefix, filters)(ec)
 }
 
 final case class ResponseError(status: Int, msg: String)
@@ -98,7 +100,15 @@ final class BakerClient(
     }
   }
 
-  private def root(rootUri: Uri): Uri = rootUri / "api" / "bakery"
+  private def root(host: Uri): Uri = {
+    val hostString = host.renderString
+    val prefix = if (hostString.endsWith("/")) hostString.dropRight(1) else hostString
+    val suffix = if (apiUrlPrefix.startsWith("/")) apiUrlPrefix.substring(1) else apiUrlPrefix
+    val uriString = s"$prefix/$suffix"
+    Uri.fromString(uriString).getOrElse(
+      throw new IllegalArgumentException(s"API URI '$uriString' is not a valid URI")
+    )
+  }
 
   private def handleHttpErrors(errorResponse: Response[IO]): IO[Throwable] =
     errorResponse.bodyText.compile.foldMonoid.map(body => ResponseError(errorResponse.status.code, body))
@@ -144,7 +154,7 @@ final class BakerClient(
     * @return
     */
   override def bake(recipeId: String, recipeInstanceId: String): Future[Unit] =
-    callRemoteBaker[Unit](uri => POST(root(uri) / "instances" / recipeInstanceId / "bake" / recipeId)).map { _ =>
+    callRemoteBaker[Unit](host => POST(root(host) / "instances" / recipeInstanceId / "bake" / recipeId)).map { _ =>
       logger.info(s"Baked recipe instance '$recipeInstanceId' from recipe '$recipeId'")
     }
 
@@ -163,7 +173,7 @@ final class BakerClient(
                                                 event: EventInstance,
                                                 correlationId: Option[String]): Future[SensoryEventResult] =
     callRemoteBaker[SensoryEventResult](
-      uri => POST(event, (root(uri) / "instances" / recipeInstanceId / "fire-and-resolve-when-completed")
+      host => POST(event, (root(host) / "instances" / recipeInstanceId / "fire-and-resolve-when-completed")
         .withOptionQueryParam("correlationId", correlationId))).map { result =>
       logger.info(s"For recipe instance '$recipeInstanceId', fired and completed event '${event.name}', resulting status ${result.sensoryEventStatus}")
       logger.debug(s"Resulting ingredients ${result.ingredients.map { case (ingredient, value) => s"$ingredient=$value" }.mkString(", ")}")
@@ -185,7 +195,7 @@ final class BakerClient(
                                                event: EventInstance,
                                                correlationId: Option[String]): Future[SensoryEventStatus] =
     callRemoteBaker[SensoryEventStatus](
-      uri => POST(event, (root(uri) / "instances" / recipeInstanceId / "fire-and-resolve-when-received")
+      host => POST(event, (root(host) / "instances" / recipeInstanceId / "fire-and-resolve-when-received")
         .withOptionQueryParam("correlationId", correlationId))).map { result =>
       logger.info(s"For recipe instance '$recipeInstanceId', fired and received event '${event.name}', resulting status $result")
       result
@@ -208,7 +218,7 @@ final class BakerClient(
                                           onEvent: String,
                                           correlationId: Option[String]): Future[SensoryEventResult] =
     callRemoteBaker[SensoryEventResult](
-      uri => POST(event, (root(uri) / "instances" / recipeInstanceId / "fire-and-resolve-on-event" / onEvent)
+      host => POST(event, (root(host) / "instances" / recipeInstanceId / "fire-and-resolve-on-event" / onEvent)
         .withOptionQueryParam("correlationId", correlationId))).map { result =>
       logger.info(s"For recipe instance '$recipeInstanceId', fired event '${event.name}', and resolved on event '$onEvent', resulting status ${result.sensoryEventStatus}")
       logger.debug(s"Resulting ingredients ${result.ingredients.map { case (ingredient, value) => s"$ingredient=$value" }.mkString(", ")}")
@@ -242,7 +252,7 @@ final class BakerClient(
     * @return An index of all processes
     */
   override def getAllRecipeInstancesMetadata: Future[Set[RecipeInstanceMetadata]] =
-    callRemoteBaker[Set[RecipeInstanceMetadata]](uri => GET(root(uri) / "instances"))
+    callRemoteBaker[Set[RecipeInstanceMetadata]](host => GET(root(host) / "instances"))
 
   /**
     * Returns the process state.
@@ -251,7 +261,7 @@ final class BakerClient(
     * @return The process state.
     */
   override def getRecipeInstanceState(recipeInstanceId: String): Future[RecipeInstanceState] =
-    callRemoteBaker[RecipeInstanceState](uri => GET(root(uri) / "instances" / recipeInstanceId))
+    callRemoteBaker[RecipeInstanceState](host => GET(root(host) / "instances" / recipeInstanceId))
 
   /**
     * Returns all provided ingredients for a given RecipeInstance id.
@@ -260,7 +270,7 @@ final class BakerClient(
     * @return The provided ingredients.
     */
   override def getIngredients(recipeInstanceId: String): Future[Map[String, Value]] =
-    callRemoteBaker[Map[String, Value]](uri => GET(root(uri) / "instances" / recipeInstanceId / "ingredients"))
+    callRemoteBaker[Map[String, Value]](host => GET(root(host) / "instances" / recipeInstanceId / "ingredients"))
 
   /**
     * Returns all fired events for a given RecipeInstance id.
@@ -269,7 +279,7 @@ final class BakerClient(
     * @return The events
     */
   override def getEvents(recipeInstanceId: String): Future[Seq[EventMoment]] =
-    callRemoteBaker[List[EventMoment]](uri => GET(root(uri) / "instances" / recipeInstanceId / "events"))
+    callRemoteBaker[List[EventMoment]](host => GET(root(host) / "instances" / recipeInstanceId / "events"))
 
   /**
     * Returns all names of fired events for a given RecipeInstance id.
@@ -287,7 +297,7 @@ final class BakerClient(
     * @return A visual (.dot) representation of the process state.
     */
   override def getVisualState(recipeInstanceId: String, style: RecipeVisualStyle): Future[String] =
-    callRemoteBaker[String](uri => GET(root(uri) / "instances" / recipeInstanceId / "visual"))
+    callRemoteBaker[String](host => GET(root(host) / "instances" / recipeInstanceId / "visual"))
 
   /**
     * Registers a listener to all runtime events for recipes with the given name run in this baker instance.
@@ -344,7 +354,7 @@ final class BakerClient(
     * @return
     */
   override def retryInteraction(recipeInstanceId: String, interactionName: String): Future[Unit] =
-    callRemoteBaker[Unit](uri => POST(root(uri) / "instances" / recipeInstanceId / "interaction" / interactionName / "retry"))
+    callRemoteBaker[Unit](host => POST(root(host) / "instances" / recipeInstanceId / "interaction" / interactionName / "retry"))
 
   /**
     * Resolves a blocked interaction by specifying it's output.
@@ -354,7 +364,7 @@ final class BakerClient(
     * @return
     */
   override def resolveInteraction(recipeInstanceId: String, interactionName: String, event: EventInstance): Future[Unit] =
-    callRemoteBaker[Unit](uri => POST(event, root(uri) / "instances" / recipeInstanceId / "interaction" / interactionName / "resolve"))
+    callRemoteBaker[Unit](host => POST(event, root(host) / "instances" / recipeInstanceId / "interaction" / interactionName / "resolve"))
 
   /**
     * Stops the retrying of an interaction.
@@ -362,5 +372,5 @@ final class BakerClient(
     * @return
     */
   override def stopRetryingInteraction(recipeInstanceId: String, interactionName: String): Future[Unit] =
-    callRemoteBaker[Unit](uri => POST(root(uri) / "instances" / recipeInstanceId / "interaction" / interactionName / "stop-retrying"))
+    callRemoteBaker[Unit](host => POST(root(host) / "instances" / recipeInstanceId / "interaction" / interactionName / "stop-retrying"))
 }

--- a/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
+++ b/bakery/baker-client/src/main/scala/com/ing/bakery/scaladsl/BakerClient.scala
@@ -28,6 +28,7 @@ object BakerClient {
     *
     * This method supports fail over to next host, available in list to support multi datacenters.
     * @param hosts Lists of hosts (multiple is supported for several DC)
+    * @param apiUrlPrefix Prefix of Baker API URL, from the root of the host
     * @param executionContext Execution Context
     * @param filters Http Filters to be applied to the invocation pipeline
     * @param tlsConfig TLSConfig
@@ -56,6 +57,7 @@ object BakerClient {
     * Creates client to remote Baker cluster
     *
     * @param host Baker host
+    * @param apiUrlPrefix Prefix of Baker API URL, from the root of the host
     * @param executionContext Execution Context
     * @param filters Http Filters to be applied to the invocation pipeline
     * @param tlsConfig TLSConfig

--- a/bakery/baker-client/src/test/scala/com/ing/bakery/common/FailoverStateSpec.scala
+++ b/bakery/baker-client/src/test/scala/com/ing/bakery/common/FailoverStateSpec.scala
@@ -19,14 +19,14 @@ class FailoverStateSpec extends AnyFunSpec {
 
       val fos = new FailoverState(IndexedSeq(uriA))
 
-      assert(fos.host == uriA)
+      assert(fos.uri == uriA)
 
       fos.failed()
 
-      assert(fos.host == uriA)
+      assert(fos.uri == uriA)
 
       (1 to 10).foreach(_ => fos.failed())
-      assert(fos.host == uriA)
+      assert(fos.uri == uriA)
     }
 
 
@@ -34,32 +34,32 @@ class FailoverStateSpec extends AnyFunSpec {
 
       val fos = new FailoverState(IndexedSeq.empty)
 
-      assertThrows[IndexOutOfBoundsException](fos.host)
+      assertThrows[IndexOutOfBoundsException](fos.uri)
 
       fos.failed()
 
-      assertThrows[IndexOutOfBoundsException](fos.host)
+      assertThrows[IndexOutOfBoundsException](fos.uri)
     }
 
     it("should support multiply elements") {
       val fos = new FailoverState(IndexedSeq(uriA, uriB))
 
-      assert(fos.host == uriA)
+      assert(fos.uri == uriA)
 
       fos.failed()
 
-      assert(fos.host == uriB)
+      assert(fos.uri == uriB)
 
       fos.failed()
 
-      assert(fos.host == uriA)
+      assert(fos.uri == uriA)
 
       implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
       val result = Future.sequence(
         (1 to 1000).map(_ => Future {
           fos.failed()
-          val currentHost = fos.host // Because of concurrency checking host at any random time
+          val currentHost = fos.uri // Because of concurrency checking host at any random time
           assert(currentHost == uriA || currentHost == uriB)
         }))
 

--- a/bakery/baker/src/test/scala/com/ing/bakery/baker/BakerNodeSpec.scala
+++ b/bakery/baker/src/test/scala/com/ing/bakery/baker/BakerNodeSpec.scala
@@ -401,7 +401,7 @@ class BakerNodeSpec extends BakeryFunSpec with Matchers {
       _ <- Resource.liftF(RecipeLoader.loadRecipesIntoBaker(getResourceDirectoryPathSafe, baker))
 
       server <- BakerService.resource(baker, InetSocketAddress.createUnresolved("127.0.0.1", 0), serviceDiscovery, loggingEnabled = true)
-      client <- BakerClient.resource(server.baseUri, executionContext)
+      client <- BakerClient.resource(server.baseUri, "/api/bakery", executionContext)
 
     } yield Context(
       client,

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   crossScalaVersions := Seq("2.12.11"),
   fork := true,
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
-  javacOptions := Seq("-source", jvmV, "-target", jvmV),
   scalacOptions := Seq(
     "-unchecked",
     "-deprecation",
@@ -36,7 +35,6 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     "-language:implicitConversions",
     "-language:postfixOps",
     "-encoding", "utf8",
-    s"-target:jvm-$jvmV",
     "-Xfatal-warnings"
   ),
   coverageExcludedPackages := "<empty>;.*javadsl.*;.*scaladsl.*;.*common.*;.*protobuf.*;.*Main.*",

--- a/examples/bakery-client-example/src/main/scala/webshop/webservice/Main.scala
+++ b/examples/bakery-client-example/src/main/scala/webshop/webservice/Main.scala
@@ -33,7 +33,7 @@ object Main extends IOApp {
       ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
 
     val mainResource = for {
-      baker <- BakerClient.resource(Uri.unsafeFromString(bakeryHostname), connectionPool)
+      baker <- BakerClient.resource(Uri.unsafeFromString(bakeryHostname), "/api/bakery", connectionPool)
       management <- StateNodeManagementClient.resource(Uri.unsafeFromString(bakeryHostname), connectionPool)
       _ <- BlazeServerBuilder[IO](connectionPool)
         .bindHttp(httpPort, "0.0.0.0")

--- a/project/BuildInteractionDockerImageSBTPlugin.scala
+++ b/project/BuildInteractionDockerImageSBTPlugin.scala
@@ -78,6 +78,7 @@ object BuildInteractionDockerImageSBTPlugin extends sbt.AutoPlugin {
           version in ThisBuild := moduleID.map(_.revision).getOrElse((version in ThisBuild).value),
           javaOptions in Universal += arguments.interactions.mkString(","),
           livenessProbe in kube := NoProbe,
+          dockerBaseImage := "adoptopenjdk/openjdk11",
           sourceGenerators in Compile += Def.task {
             val mainClassName =
               (mainClass in Compile).value.getOrElse(throw new MessageOnlyException("mainClass in Compile is required"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
 
   val scalaGraph = "org.scala-graph" %% "graph-core" % "1.13.1"
   val scalaGraphDot = "org.scala-graph" %% "graph-dot" % "1.13.0"
-  val graphvizJava = "guru.nidi" % "graphviz-java" % "0.17.0"
+  val graphvizJava = "guru.nidi" % "graphviz-java" % "0.17.1"
 
   val kamon = "io.kamon" %% "kamon-bundle" % kamonAkkaVersion
   val kamonAkka = "io.kamon" %% "kamon-akka" % kamonAkkaVersion
@@ -104,7 +104,7 @@ object Dependencies {
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.30"
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val logstash =  "net.logstash.logback" % "logstash-logback-encoder" % "6.4"
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.3"
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.15.0"
   val scalaCheckPlus = "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"
   val scalaCheckPlusMockito = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,14 +3,13 @@ import sbt._
 //noinspection TypeAnnotation
 object Dependencies {
 
-  val akkaVersion = "2.6.9"
-  val akkaManagementVersion = "1.0.8"
+  val akkaVersion = "2.6.10"
+  val akkaManagementVersion = "1.0.9"
   val akkaHttpVersion = "10.2.1"
   val http4sVersion = "0.21.8"
   val circeVersion = "0.13.0"
   val kamonAkkaVersion = "2.1.8"
 
-  val jvmV = "1.8"
   val scalapbVersion = scalapb.compiler.Version.scalapbVersion
 
   val akkaInmemoryJournal = ("com.github.dnvriend" %% "akka-persistence-inmemory" % "2.5.15.2")
@@ -36,7 +35,7 @@ object Dependencies {
   val akkaPersistence = "com.typesafe.akka" %% "akka-persistence" % akkaVersion
   val akkaDiscovery = "com.typesafe.akka" %% "akka-discovery" % akkaVersion
   val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion
-  val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.104"
+  val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.105"
   val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % akkaVersion
   val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion
   val akkaClusterTools = "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion
@@ -98,10 +97,10 @@ object Dependencies {
 
   val betterFiles = "com.github.pathikrit" %% "better-files" % "3.9.1"
 
-  val typeSafeConfig = "com.typesafe" % "config" % "1.4.0"
+  val typeSafeConfig = "com.typesafe" % "config" % "1.4.1"
 
   val objenisis = "org.objenesis" % "objenesis" % "3.1"
-  val jodaTime = "joda-time" % "joda-time" % "2.10.7"
+  val jodaTime = "joda-time" % "joda-time" % "2.10.8"
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.30"
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val logstash =  "net.logstash.logback" % "logstash-logback-encoder" % "6.4"
@@ -111,8 +110,8 @@ object Dependencies {
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 
 
-  val springContext = "org.springframework" % "spring-context" % "5.2.9.RELEASE"
-  val springCore = "org.springframework" % "spring-core" % "5.2.9.RELEASE"
+  val springContext = "org.springframework" % "spring-context" % "5.2.10.RELEASE"
+  val springCore = "org.springframework" % "spring-core" % "5.2.10.RELEASE"
 
   def scopeDeps(scope: String, modules: Seq[ModuleID]) = modules.map(m => m % scope)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
 
   val akkaVersion = "2.6.10"
   val akkaManagementVersion = "1.0.9"
+  val akkaPersistenceCassandraVersion = "1.0.3"
   val akkaHttpVersion = "10.2.1"
   val http4sVersion = "0.21.8"
   val circeVersion = "0.13.0"
@@ -35,7 +36,7 @@ object Dependencies {
   val akkaPersistence = "com.typesafe.akka" %% "akka-persistence" % akkaVersion
   val akkaDiscovery = "com.typesafe.akka" %% "akka-discovery" % akkaVersion
   val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion
-  val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.105"
+  val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % akkaPersistenceCassandraVersion
   val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % akkaVersion
   val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion
   val akkaClusterTools = "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.4.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.4.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.6")
 
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.6")
 
 addSbtPlugin("org.vaslabs.kube" % "sbt-kubeyml" % "0.3.9")
 


### PR DESCRIPTION
- several version bumps of deps
- default JDK11 build
- /api/bakery prefix is configurable now in the client
