### PR TITLE
Make k8s aware interactions registry as optional module toggled by co…

### DIFF
--- a/bakery/baker-state-k8s/src/main/resources/reference.conf
+++ b/bakery/baker-state-k8s/src/main/resources/reference.conf
@@ -1,0 +1,16 @@
+
+
+skuber {
+  watch-continuously {
+    idle-timeout = 172800s
+  }
+}
+
+baker {
+  interactions {
+    kubernetes {
+      api-url-prefix = "/api/bakery/interactions"
+      pod-label-selector = ""
+    }
+  }
+}

--- a/bakery/baker-state-k8s/src/main/scala/com/ing/bakery/baker/KubernetesInteractions.scala
+++ b/bakery/baker-state-k8s/src/main/scala/com/ing/bakery/baker/KubernetesInteractions.scala
@@ -1,8 +1,8 @@
 package com.ing.bakery.baker
 
 import akka.actor.ActorSystem
+import akka.stream._
 import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source, TcpIdleTimeoutException}
-import akka.stream.{KillSwitch, KillSwitches, Materializer, RestartSettings, UniqueKillSwitch}
 import akka.{Done, NotUsed}
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.implicits.catsSyntaxApplicativeError
@@ -11,7 +11,6 @@ import com.ing.bakery.interaction.RemoteInteractionClient
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.http4s.Uri
-import org.http4s.client.Client
 import skuber.api.client.{EventType, KubernetesClient}
 import skuber.json.format._
 import skuber.{K8SWatchEvent, LabelSelector, ListOptions, Service}

--- a/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/StateRuntimeSpec.scala
+++ b/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/StateRuntimeSpec.scala
@@ -5,11 +5,12 @@ import cats.effect.{IO, Resource}
 import com.ing.baker.il.CompiledRecipe
 import com.ing.baker.runtime.akka.{AkkaBaker, AkkaBakerConfig}
 import com.ing.baker.runtime.common.BakerException.NoSuchProcessException
-import com.ing.baker.runtime.common.{BakerException, RecipeRecord, SensoryEventStatus}
+import com.ing.baker.runtime.common.{BakerException, SensoryEventStatus}
 import com.ing.baker.runtime.model.{InteractionInstance, InteractionManager}
 import com.ing.baker.runtime.scaladsl.{Baker, EventInstance, InteractionInstanceDescriptor, InteractionInstanceInput}
-import com.ing.baker.types.{ByteArray, CharArray, ListType, RecordField, RecordType}
-import com.ing.bakery.mocks.{EventListener, KubeApiServer, RemoteInteraction}
+import com.ing.baker.types._
+import com.ing.bakery.baker.mocks.KubeApiServer
+import com.ing.bakery.mocks.{EventListener, RemoteInteraction}
 import com.ing.bakery.recipe.Events.{ItemsReserved, OrderPlaced}
 import com.ing.bakery.recipe.Ingredients.{Item, OrderId, ReservedItems}
 import com.ing.bakery.recipe.{ItemReservationRecipe, SimpleRecipe, SimpleRecipe2}
@@ -49,7 +50,7 @@ class StateRuntimeSpec extends BakeryFunSpec with Matchers {
     EventInstance.unsafeFrom(
       ItemsReserved(ReservedItems(
         List(Item("item-1")),
-        Array.fill(1)(Byte.MaxValue)
+        Array.fill(1)(scala.Byte.MaxValue)
       )))
 
   def io[A](f: => Future[A]): IO[A] =
@@ -76,7 +77,7 @@ class StateRuntimeSpec extends BakeryFunSpec with Matchers {
         allRecipesAfter <- io(context.client.getAllRecipes)
       } yield {
         allRecipesBefore.values.map(_.compiledRecipe.name).toSet shouldBe Set("ItemReservation.recipe")
-        allRecipesAfter.values.map(_.compiledRecipe.name).toSet  shouldBe Set("ItemReservation.recipe", "Simple2")
+        allRecipesAfter.values.map(_.compiledRecipe.name).toSet shouldBe Set("ItemReservation.recipe", "Simple2")
       }
     }
 
@@ -452,7 +453,9 @@ class StateRuntimeSpec extends BakeryFunSpec with Matchers {
       _ = TestInteractionRegistry(mockServerKubernetes, mockServerLocalhost, remoteInteractionKubernetes, remoteInteractionLocalhost, kubeApiServer)
       _ <- Resource.eval(kubeApiServer.noNewInteractions()) // Initial setup so that the service discovery component has something to query to immediately
 
-      makeActorSystem = IO { ActorSystem(UUID.randomUUID().toString, config) }
+      makeActorSystem = IO {
+        ActorSystem(UUID.randomUUID().toString, config)
+      }
       stopActorSystem = (system: ActorSystem) => IO.fromFuture(IO {
         system.terminate().flatMap(_ => system.whenTerminated)
       }).void

--- a/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/TestInteractionRegistry.scala
+++ b/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/TestInteractionRegistry.scala
@@ -3,13 +3,13 @@ package com.ing.bakery.baker
 import akka.actor.ActorSystem
 import cats.effect.{IO, Resource}
 import com.ing.baker.runtime.model.InteractionManager
-import com.ing.bakery.interaction.{BaseRemoteInteractionClient, RemoteInteractionClient}
-import com.ing.bakery.mocks.{KubeApiServer, RemoteInteraction}
-import com.typesafe.config.{Config, ConfigValue, ConfigValueFactory}
+import com.ing.bakery.baker.mocks.KubeApiServer
+import com.ing.bakery.interaction.BaseRemoteInteractionClient
+import com.ing.bakery.mocks.RemoteInteraction
+import com.typesafe.config.{Config, ConfigValueFactory}
 import org.http4s.Headers
 import org.http4s.client.Client
 import org.mockserver.integration.ClientAndServer
-import skuber.api.client.KubernetesClient
 
 object TestInteractionRegistry {
   var mockServerKubernetes: ClientAndServer = _
@@ -33,17 +33,19 @@ object TestInteractionRegistry {
 }
 
 class TestInteractionRegistry(c: Config, system: ActorSystem) extends BaseInteractionRegistry(c, system) {
-    import TestInteractionRegistry._
-    override protected def interactionManagersResource(client: Client[IO]): Resource[IO, List[InteractionManager[IO]]] = {
-      val config = c.withValue("baker.interactions.localhost.port", ConfigValueFactory.fromAnyRef(mockServerLocalhost.getLocalPort))
-      for {
-        localhost <- new LocalhostInteractions(config, system,
-          new BaseRemoteInteractionClient(client, Headers.empty)).resource
-        kubernetes <- new KubernetesInteractions(
-          config, system, new BaseRemoteInteractionClient(client, Headers.empty),
-          Some(skuber.k8sInit(skuber.api.Configuration.useLocalProxyOnPort(mockServerKubernetes.getLocalPort))(system))
-        ).resource
-      } yield List(kubernetes, localhost)
-    }
+
+  import TestInteractionRegistry._
+
+  override protected def interactionManagersResource(client: Client[IO]): Resource[IO, List[InteractionManager[IO]]] = {
+    val config = c.withValue("baker.interactions.localhost.port", ConfigValueFactory.fromAnyRef(mockServerLocalhost.getLocalPort))
+    for {
+      localhost <- new LocalhostInteractions(config, system,
+        new BaseRemoteInteractionClient(client, Headers.empty)).resource
+      kubernetes <- new KubernetesInteractions(
+        config, system, new BaseRemoteInteractionClient(client, Headers.empty),
+        Some(skuber.k8sInit(skuber.api.Configuration.useLocalProxyOnPort(mockServerKubernetes.getLocalPort))(system))
+      ).resource
+    } yield List(kubernetes, localhost)
+  }
 
 }

--- a/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/mocks/KubeApiServer.scala
+++ b/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/mocks/KubeApiServer.scala
@@ -1,8 +1,7 @@
-package com.ing.bakery.mocks
+package com.ing.bakery.baker.mocks
 
 import cats.effect.IO
-import com.ing.baker.runtime.scaladsl.InteractionInstance
-import com.ing.bakery.mocks.WatchEvent.WatchEventType
+import com.ing.bakery.baker.mocks.WatchEvent.WatchEventType
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.matchers.{TimeToLive, Times}
 import org.mockserver.model.HttpRequest.request

--- a/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/mocks/WatchEvent.scala
+++ b/bakery/baker-state-k8s/src/test/scala/com/ing/bakery/baker/mocks/WatchEvent.scala
@@ -1,4 +1,4 @@
-package com.ing.bakery.mocks
+package com.ing.bakery.baker.mocks
 
 import play.api.libs.json.Format
 

--- a/bakery/state/src/main/resources/reference.conf
+++ b/bakery/state/src/main/resources/reference.conf
@@ -1,11 +1,5 @@
 include "baker.conf"
 
-skuber {
-  watch-continuously {
-    idle-timeout = 172800s
-  }
-}
-
 baker {
   watcher {
     class = ""
@@ -38,9 +32,10 @@ baker {
       port = 8081
       api-url-prefix = "/api/bakery/interactions"
     }
-    kubernetes {
-      api-url-prefix = "/api/bakery/interactions"
-      pod-label-selector = ""
+
+    remote {
+        # extra DynamicInteractionManager, for example com.ing.bakery.baker.KubernetesInteractions
+        class = ""
     }
 
     # amount of time to wait before failing an interaction when the remote interaction manager can't find an interaction node to run on

--- a/bakery/state/src/main/scala/com/ing/bakery/baker/InteractionRegistry.scala
+++ b/bakery/state/src/main/scala/com/ing/bakery/baker/InteractionRegistry.scala
@@ -1,16 +1,18 @@
 package com.ing.bakery.baker
 
 import akka.actor.ActorSystem
+import cats.Traverse
 import cats.effect.{ConcurrentEffect, ContextShift, IO, Resource, Timer}
-import cats.syntax.traverse._
+import cats.syntax.all._
+import com.ing.baker.runtime.akka.internal.DynamicInteractionManager
 import com.ing.baker.runtime.defaultinteractions
 import com.ing.baker.runtime.model.{InteractionInstance, InteractionManager}
 import com.ing.bakery.interaction.{BaseRemoteInteractionClient, RemoteInteractionClient}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import org.http4s.{Headers, Uri}
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.{Headers, Uri}
 import scalax.collection.ChainingOps
 
 import java.io.IOException
@@ -41,6 +43,7 @@ object InteractionRegistry extends LazyLogging {
   */
 trait InteractionRegistry extends InteractionManager[IO] {
   def resource(externalContext: Option[Any]): Resource[IO, InteractionRegistry]
+
   def interactionManagers: IO[List[InteractionManager[IO]]]
 }
 
@@ -81,28 +84,40 @@ class BaseInteractionRegistry(config: Config, actorSystem: ActorSystem)
     }
   }
 
-  protected def interactionManagersResource(client: Client[IO])
-  : Resource[IO, List[InteractionManager[IO]]] = {
+  protected def interactionManagersResource(client: Client[IO]): Resource[IO, List[InteractionManager[IO]]] = {
 
     val interactionClient = new BaseRemoteInteractionClient(client, Headers.empty)
 
-    for {
-      localhost <- new LocalhostInteractions(config, actorSystem, interactionClient).resource
-      kubernetes <- new KubernetesInteractions(config, actorSystem, interactionClient).resource
-    } yield {
-      List(localhost, kubernetes)
+    def getRemoteInteractions: Option[DynamicInteractionManager] = {
+      val path = "baker.interactions.remote.class"
+
+      def noneIfEmpty(str: String): Option[String] = if (str.isEmpty) None else Some(str)
+
+      if (config.hasPath(path)) noneIfEmpty(config.getString(path)).map {
+        Class.forName(_)
+          .getDeclaredConstructor(classOf[Config], classOf[ActorSystem], classOf[RemoteInteractionClient])
+          .newInstance(config, actorSystem, interactionClient)
+          .asInstanceOf[DynamicInteractionManager]
+      } else {
+        None
+      }
     }
+
+    val local = new LocalhostInteractions(config, actorSystem, interactionClient)
+
+    val lists = getRemoteInteractions
+      .map(r => List(local, r))
+      .getOrElse(List(local))
+      .map(_.resource)
+
+    Traverse[List].sequence(lists)
   }
 }
 
 case class RemoteInteractions(startedAt: Long,
                               interactions: List[InteractionInstance[IO]])
 
-//trait RemoteInteractionClient {
-//  def remoteInteractionClient(client: Client[IO], uri: Uri)
-//                             (implicit contextShift: ContextShift[IO], timer: Timer[IO]): RemoteInteractionClient =
-//    new BaseRemoteInteractionClient(client, uri, Headers.empty)
-//}
+
 /**
   * Method for resilient/retrying discovery of remote interactions
   */

--- a/build.sbt
+++ b/build.sbt
@@ -290,11 +290,47 @@ lazy val `bakery-dashboard`: Project = project.in(file("bakery/dashboard"))
     Compile / packageDoc / publishArtifact := false,
     Compile / packageSrc / publishArtifact := false,
     Compile / packageBin / publishArtifact := false,
-    Universal / packageBin  := npmBuildTask.value,
+    Universal / packageBin := npmBuildTask.value,
     addArtifact(Artifact("dashboard", "zip", "zip"), npmBuildTask),
     publish := (publish dependsOn (Universal / packageBin)).value,
     publishLocal := (publishLocal dependsOn (Universal / packageBin)).value
   )
+
+lazy val `bakery-state-k8s`: Project = project.in(file("bakery/baker-state-k8s"))
+  .settings(defaultModuleSettings)
+  .settings(
+    moduleName := "bakery-state-k8s",
+    scalacOptions ++= Seq(
+      "-Ypartial-unification"
+    ),
+    libraryDependencies ++= Seq(
+      skuber
+    ) ++ testDeps(
+      slf4jApi,
+      logback,
+      scalaTest,
+      mockServer,
+      circe,
+      circeGeneric,
+      akkaInmemoryJournal,
+      cassandraDriverCore,
+      cassandraDriverQueryBuilder,
+      cassandraDriverMetrics,
+      cassandraUnit
+    )
+  )
+  .dependsOn(
+    `baker-akka-runtime`,
+    `bakery-client`,
+    `baker-interface`,
+    `bakery-interaction-protocol`,
+    `baker-recipe-compiler`,
+    `baker-recipe-dsl`,
+    `baker-intermediate-language`,
+    `bakery-dashboard`,
+    `bakery-state` % "compile->compile;test->test"
+  )
+
 
 lazy val `bakery-state`: Project = project.in(file("bakery/state"))
   .enablePlugins(JavaAppPackaging, DockerPlugin)
@@ -325,8 +361,7 @@ lazy val `bakery-state`: Project = project.in(file("bakery/state"))
       http4sDsl,
       http4sCirce,
       http4sServer,
-      kafkaClient,
-      skuber
+      kafkaClient
     ) ++ testDeps(
       slf4jApi,
       logback,
@@ -399,7 +434,7 @@ lazy val baker: Project = project.in(file("."))
   .settings(defaultModuleSettings)
   .aggregate(`baker-types`, `baker-akka-runtime`, `baker-recipe-compiler`, `baker-recipe-dsl`, `baker-intermediate-language`,
     `bakery-client`, `bakery-state`, `bakery-interaction`, `bakery-interaction-spring`, `bakery-interaction-protocol`,
-    `sbt-bakery-docker-generate`,
+    `sbt-bakery-docker-generate`, `bakery-state-k8s`,
     `baker-interface`, `bakery-dashboard`, `baker-annotations`, `baker-test`)
 
 lazy val `baker-example`: Project = project


### PR DESCRIPTION
Make k8s aware interactions registry as optional module toggled by baker.interactions.remote.class configuration. This allows to exclude skuber from mandatory dependencies