### PR TITLE
Fix classpath issues of bakery-state

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,21 +53,12 @@ val dockerSettings: Seq[Setting[_]] = Seq(
   Docker / version := "local", // used by smoke tests for locally built images
 )
 
-val dependencyOverrideSettingsBouncyCastle: Seq[Setting[_]] = Seq(
-  libraryDependencies ++= Seq(
-    bouncyCastleBcprov,
-    bouncyCastleBcpkix
-  ),
-  dependencyOverrides ++= Seq(
-    bouncyCastleBcprov,
-    bouncyCastleBcpkix
-  )
-)
-
 val dependencyOverrideSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     snakeYaml,
     jacksonDatabind,
+    bouncyCastleBcprov,
+    bouncyCastleBcpkix
   ),
   dependencyOverrides ++= Seq(
     catsCore,
@@ -77,6 +68,8 @@ val dependencyOverrideSettings: Seq[Setting[_]] = Seq(
     jnrConstants,
     snakeYaml,
     jacksonDatabind,
+    bouncyCastleBcprov,
+    bouncyCastleBcpkix
   )
 )
 
@@ -86,8 +79,7 @@ lazy val noPublishSettings: Seq[Setting[_]] = Seq(
   publishArtifact := false
 )
 
-lazy val moduleSettingsWithoutBouncyCastle: Seq[Setting[_]] = commonSettings ++ dependencyOverrideSettings ++ Publish.settings
-lazy val defaultModuleSettings: Seq[Setting[_]] = moduleSettingsWithoutBouncyCastle ++ dependencyOverrideSettingsBouncyCastle
+lazy val defaultModuleSettings: Seq[Setting[_]] = commonSettings ++ dependencyOverrideSettings ++ Publish.settings
 
 lazy val scalaPBSettings: Seq[Setting[_]] = Seq(Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value))
 
@@ -306,7 +298,7 @@ lazy val `bakery-dashboard`: Project = project.in(file("bakery/dashboard"))
 
 lazy val `bakery-state`: Project = project.in(file("bakery/state"))
   .enablePlugins(JavaAppPackaging, DockerPlugin)
-  .settings(moduleSettingsWithoutBouncyCastle)
+  .settings(defaultModuleSettings)
   .settings(
     Compile / mainClass := Some("com.ing.bakery.baker.Main"),
     dockerExposedPorts ++= Seq(8080),
@@ -348,13 +340,6 @@ lazy val `bakery-state`: Project = project.in(file("bakery/state"))
       cassandraDriverQueryBuilder,
       cassandraDriverMetrics,
       cassandraUnit
-    )
-  )
-  .settings(
-    // Skuber adds bc-fips and bcpkix-fips instead
-    excludeDependencies ++= Seq(
-      ExclusionRule(organization = bouncyCastleBcprov.organization, name = bouncyCastleBcprov.name),
-      ExclusionRule(organization = bouncyCastleBcpkix.organization, name = bouncyCastleBcpkix.name)
     )
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,7 @@ lazy val `bakery-state`: Project = project.in(file("bakery/state"))
       akkaClusterMetrics,
       akkaDiscovery,
       akkaDiscoveryKube,
+      akkaPki,
       http4s,
       http4sDsl,
       http4sCirce,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   val cassandraDriverQueryBuilder = "com.datastax.oss" % "java-driver-query-builder" % "4.13.0"
   val cassandraDriverMetrics = "io.dropwizard.metrics" % "metrics-jmx" % "4.2.7"
 
-  val skuber = "io.skuber" %% "skuber" % "2.6.3"
+  val skuber = "io.skuber" %% "skuber" % "2.6.4"
   val play = "com.typesafe.play" %% "play-json" % "2.9.2"
 
   val http4s = "org.http4s" %% "http4s-core" % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,6 +48,7 @@ object Dependencies {
   val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
   val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion
   val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion
+  val akkaPki = "com.typesafe.akka" %% "akka-pki" % akkaVersion
   val akkaHttpSprayJson = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
   val akkaManagementHttp = "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaManagementVersion
   val akkaClusterBoostrap = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion


### PR DESCRIPTION
- Added akka pki library explicitly, since it's implicitly added by the akka management library, but from there it's not the same version as the other akka libraries.
- ~~Excluded normal bcprov dependencies from bakery-state, because different bcprov version is used by skuber, which conflicts with the standard bcprov dependencies.~~ Updated version of skuber to 2.6.4.

These changes help reduce the number of classpath issues you need to solve to use bakery-state.