### PR TITLE
BackoffSupervisor for ProcessIndex & ProcessInstance

### DIFF
--- a/core/akka-runtime/src/main/resources/reference.conf
+++ b/core/akka-runtime/src/main/resources/reference.conf
@@ -38,6 +38,20 @@ baker {
   # the time to wait for a gracefull shutdown
   shutdown-timeout = 30 seconds
 
+  process-index {
+    # Configurations for the restart policy for the ProcessIndex actor
+    restart-minBackoff = 1 seconds
+    restart-maxBackoff = 30 seconds
+    restart-randomFactor = 0.2
+  }
+
+  process-instance {
+    # Configurations for the restart policy for the ProcessInstance actor
+    restart-minBackoff = 1 seconds
+    restart-maxBackoff = 30 seconds
+    restart-randomFactor = 0.2
+  }
+
   # The ingredients that are filtered out when getting the process instance.
   # This should be used if there are big ingredients to improve performance and memory usage.
   # The ingredients will be in the ingredients map but there value will be an empty String.

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
@@ -82,7 +82,7 @@ class AkkaBaker private[runtime](config: AkkaBakerConfig) extends scaladsl.Baker
     config.recipeManager
 
   private val processIndexActor: ActorRef =
-    config.bakerActorProvider.createProcessIndexActor(config.interactions, recipeManager)
+    config.bakerActorProvider.createProcessIndexActor(config.interactions, recipeManager, system.settings.config)
 
   /**
     * Adds a recipe to baker and returns a recipeId for the recipe.

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/BakerActorProvider.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/BakerActorProvider.scala
@@ -5,6 +5,7 @@ import cats.effect.IO
 import com.ing.baker.runtime.akka.actor.process_index.ProcessIndex.ActorMetadata
 import com.ing.baker.runtime.model.InteractionManager
 import com.ing.baker.runtime.recipe_manager.RecipeManager
+import com.typesafe.config.Config
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -12,7 +13,7 @@ trait BakerActorProvider extends {
 
   def initialize(implicit system: ActorSystem): Unit
 
-  def createProcessIndexActor(interactionManager: InteractionManager[IO], recipeManager: RecipeManager)(implicit actorSystem: ActorSystem) : ActorRef
+  def createProcessIndexActor(interactionManager: InteractionManager[IO], recipeManager: RecipeManager, config: Config)(implicit actorSystem: ActorSystem) : ActorRef
 
   def getAllProcessesMetadata(actorRef: ActorRef)(implicit system: ActorSystem, timeout: FiniteDuration): Seq[ActorMetadata]
 }

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/LocalBakerActorProvider.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/LocalBakerActorProvider.scala
@@ -10,6 +10,8 @@ import com.ing.baker.runtime.akka.actor.process_index.ProcessIndexProtocol.{GetI
 import com.ing.baker.runtime.model.InteractionManager
 import com.ing.baker.runtime.recipe_manager.RecipeManager
 import com.ing.baker.runtime.serialization.Encryption
+import com.typesafe.config.Config
+import com.ing.baker.runtime.akka._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -23,8 +25,13 @@ class LocalBakerActorProvider(
                              ) extends BakerActorProvider {
   override def initialize(implicit system: ActorSystem): Unit = Unit
 
-  override def createProcessIndexActor(interactionManager: InteractionManager[IO], recipeManager: RecipeManager)(
+  override def createProcessIndexActor(interactionManager: InteractionManager[IO], recipeManager: RecipeManager, config: Config)(
     implicit actorSystem: ActorSystem): ActorRef = {
+
+    val restartMinBackoff: FiniteDuration =  config.getDuration("baker.process-index.restart-minBackoff").toScala
+    val restartMaxBackoff: FiniteDuration =  config.getDuration("baker.process-index.restart-maxBackoff").toScala
+    val restartRandomFactor: Double =  config.getDouble("baker.process-index.restart-randomFactor")
+
     actorSystem.actorOf(
       BackoffSupervisor.props(
         BackoffOpts
@@ -37,9 +44,9 @@ class LocalBakerActorProvider(
               recipeManager,
               ingredientsFilter),
             childName = "ProcessIndexActor",
-            minBackoff = 1 seconds,
-            maxBackoff = 10 seconds,
-            randomFactor = 0))
+            minBackoff = restartMinBackoff,
+            maxBackoff = restartMaxBackoff,
+            randomFactor = restartRandomFactor))
       )
   }
 

--- a/core/akka-runtime/src/test/java/com/ing/baker/BakerTest.java
+++ b/core/akka-runtime/src/test/java/com/ing/baker/BakerTest.java
@@ -107,6 +107,8 @@ public class BakerTest {
 
     @Test
     public void shouldExecuteCompleteFlow() throws BakerException, ExecutionException, InterruptedException {
+        actorSystem.terminate();
+        actorSystem = ActorSystem.apply("shouldExecuteCompleteFlow");
 
         Baker jBaker = AkkaBaker.java(config, actorSystem, implementationsList);
 


### PR DESCRIPTION
If a Persistent Actor has any persistence error it will be stopped and not restarted. To ensure the ProcessIndex and ProcessInstance are restarted if there are hickups against Cassandra a BackoffSupervisor needs to be configured.