### PR TITLE
Feature/support wildcard types for kotlin

### DIFF
--- a/core/baker-types/src/main/scala/com/ing/baker/types/TypeAdapter.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/TypeAdapter.scala
@@ -1,7 +1,6 @@
 package com.ing.baker.types
 
-import java.lang.reflect.ParameterizedType
-
+import java.lang.reflect.{ParameterizedType, WildcardType}
 import com.ing.baker.types.Converters.readJavaType
 import com.ing.baker.types.modules._
 
@@ -20,6 +19,8 @@ class TypeAdapter(private val modules: Map[Class[_], TypeModule]) {
     val clazz: Class[_] = javaType match {
       case c: Class[_] => c
       case genericType: ParameterizedType => getBaseClass(genericType)
+      // wildcardType is used for kotlin lists
+      case wildcardType: WildcardType if wildcardType.getUpperBounds.length == 1 && wildcardType.getLowerBounds.isEmpty => getBaseClass(wildcardType.getUpperBounds.head)
       case _ => throw new IllegalArgumentException(s"Incompatible type: $javaType")
     }
 

--- a/core/baker-types/src/test/scala/com/ing/baker/types/ComplexPOJOExample.scala
+++ b/core/baker-types/src/test/scala/com/ing/baker/types/ComplexPOJOExample.scala
@@ -2,5 +2,6 @@ package com.ing.baker.types
 
 case class ComplexPOJOExample(simplePOJOExample: SimplePOJOExample,
                               string: String,
-                              boolean: Boolean) {
+                              boolean: Boolean,
+                              upperboundRecord : List[_ <: SimplePOJOExample]) {
 }

--- a/core/baker-types/src/test/scala/com/ing/baker/types/modules/JavaModulesSpec.scala
+++ b/core/baker-types/src/test/scala/com/ing/baker/types/modules/JavaModulesSpec.scala
@@ -229,7 +229,8 @@ class JavaModulesSpec extends AnyWordSpecLike with Matchers {
       val complexPOJOExampleSeq = Seq(
         RecordField("simplePOJOExample", RecordType(simplePOJOExampleSeq)),
         RecordField("string", types.CharArray),
-        RecordField("boolean", types.Bool))
+        RecordField("boolean", types.Bool),
+        RecordField("upperboundRecord", types.ListType(RecordType(simplePOJOExampleSeq))))
 
       readJavaType[ComplexPOJOExample] shouldBe RecordType(complexPOJOExampleSeq)
     }


### PR DESCRIPTION
Allow the use of a very specific wildcard type, where the upper bound is the inner type, and there are no lower bounds.
This is to natively support kotlin lists.