### PR TITLE
Make the Config given to Bakery providable on creation.

### DIFF
--- a/bakery/state/src/main/scala/com/ing/bakery/baker/Bakery.scala
+++ b/bakery/state/src/main/scala/com/ing/bakery/baker/Bakery.scala
@@ -1,7 +1,6 @@
 package com.ing.bakery.baker
 
 import java.io.File
-
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import cats.effect.{ContextShift, IO, Resource, Timer}
@@ -9,7 +8,7 @@ import com.ing.baker.runtime.akka.{AkkaBaker, AkkaBakerConfig}
 import com.ing.baker.runtime.model.InteractionManager
 import com.ing.baker.runtime.recipe_manager.{ActorBasedRecipeManager, DefaultRecipeManager, RecipeManager}
 import com.ing.baker.runtime.scaladsl.Baker
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.LazyLogging
 import io.prometheus.client.CollectorRegistry
 import org.http4s.metrics.prometheus.Prometheus
@@ -22,11 +21,12 @@ case class Bakery(baker: Baker,
 
 object Bakery extends LazyLogging {
 
-  def resource(externalContext: Option[Any] = None,
+  def resource(optionalConfig: Option[Config],
+               externalContext: Option[Any] = None,
                interactionManager: Option[InteractionManager[IO]] = None,
                recipeManager: Option[RecipeManager] = None) : Resource[IO, Bakery] = {
     val configPath = sys.env.getOrElse("CONFIG_DIRECTORY", "/opt/docker/conf")
-    val config = ConfigFactory.load(ConfigFactory.parseFile(new File(s"$configPath/application.conf")))
+    val config = optionalConfig.getOrElse(ConfigFactory.load(ConfigFactory.parseFile(new File(s"$configPath/application.conf"))))
     val bakerConfig = config.getConfig("baker")
 
     val production = bakerConfig.getBoolean("production-safe-mode")

--- a/bakery/state/src/main/scala/com/ing/bakery/baker/ClosableBakery.scala
+++ b/bakery/state/src/main/scala/com/ing/bakery/baker/ClosableBakery.scala
@@ -1,13 +1,13 @@
 package com.ing.bakery.baker
 
 import java.io.Closeable
-
 import akka.actor.ActorSystem
 import cats.effect.IO
 import com.ing.baker.runtime.model.InteractionManager
 import com.ing.baker.runtime.recipe_manager.RecipeManager
 import com.ing.baker.runtime.scaladsl.Baker
 import com.ing.bakery.baker.Bakery.resource
+import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
 
@@ -24,10 +24,11 @@ object ClosableBakery {
     * @param externalContext optional external context in which Bakery is running, e.g. Spring context
     * @return
     */
-  def instance(externalContext: Option[Any],
+  def instance(optionalConfig: Option[Config],
+               externalContext: Option[Any],
                interactionManager: Option[InteractionManager[IO]] = None,
                recipeManager: Option[RecipeManager] = None): ClosableBakery = {
-    val (baker: Bakery, close: IO[Unit]) = resource(externalContext, interactionManager, recipeManager).allocated.unsafeRunSync()
+    val (baker: Bakery, close: IO[Unit]) = resource(optionalConfig, externalContext, interactionManager, recipeManager).allocated.unsafeRunSync()
     new ClosableBakery(baker.baker, baker.executionContext, baker.system, close)
   }
 }

--- a/bakery/state/src/main/scala/com/ing/bakery/baker/Main.scala
+++ b/bakery/state/src/main/scala/com/ing/bakery/baker/Main.scala
@@ -24,7 +24,7 @@ object Main extends IOApp with LazyLogging {
     val loggingEnabled = bakerConfig.getBoolean("api-logging-enabled")
 
     (for {
-      bakery <- Bakery.resource(None)
+      bakery <- Bakery.resource(Some(config))
       _ <- MetricService.resource(InetSocketAddress.createUnresolved("0.0.0.0", metricsPort), bakery.executionContext)
 
       bakerService <- BakerService.resource(


### PR DESCRIPTION
Make the Config given to Bakery providable on creation. Preferable I would remove the complete use of the default config that uses an environment variable to create the config from but that we need to validate if it is safe to remove.