### PR TITLE
Fix StackOverflowException in baker test

### DIFF
--- a/core/baker-test/src/test/java/com/ing/baker/test/javadsl/RecipeAssertTest.java
+++ b/core/baker-test/src/test/java/com/ing/baker/test/javadsl/RecipeAssertTest.java
@@ -1,6 +1,8 @@
 package com.ing.baker.test.javadsl;
 
 import com.ing.baker.runtime.javadsl.EventInstance;
+import com.ing.baker.runtime.common.BakerException.NoSuchProcessException;
+import com.ing.baker.test.EventsFlow;
 import com.ing.baker.test.RecipeAssert;
 import com.ing.baker.test.recipe.WebshopBaker;
 import com.ing.baker.test.recipe.WebshopRecipe;
@@ -107,5 +109,12 @@ public class RecipeAssertTest {
         createRecipeAssert()
                 .waitFor(WebshopRecipe.happyFlow())
                 .assertIngredient("orderId").is(value -> assertEquals("order-2", value.as(String.class)));
+    }
+
+    @Test(expected = NoSuchProcessException.class)
+    public void testNoSuchProcessFailure() {
+        EventsFlow flow = EventsFlow.of("Event");
+        RecipeAssert.of(WebshopBaker.javaBaker(), UUID.randomUUID().toString())
+                .waitFor(flow);
     }
 }


### PR DESCRIPTION
While using `baker-test` for testing we have noticed that if the baker recipe instance does not exist anymore while calling `assert` or `log` or `waitFor` using `BakerAssert` - you stuck in a loop and get `StackOverflowException`.

With this fix instead of `StackOverflowException` you get the original `NoSuchProcessException` which makes much more sense.