### PR TITLE
Added the addMetaData feature for the AkkaBaker.

### DIFF
--- a/core/akka-runtime/src/main/protobuf/process_index.proto
+++ b/core/akka-runtime/src/main/protobuf/process_index.proto
@@ -107,6 +107,16 @@ message NotifyOnEvent {
     optional string onEvent = 2;
 }
 
+message AddRecipeInstanceMetaDataRecord {
+    optional string key = 1;
+    optional string value = 2;
+}
+
+message AddRecipeInstanceMetaData {
+    optional string recipeInstanceId = 1;
+    repeated AddRecipeInstanceMetaDataRecord metaData = 2;
+}
+
 message RetryBlockedInteraction {
     optional string recipeInstanceId = 1;
     optional string interactionName = 2;

--- a/core/akka-runtime/src/main/protobuf/process_instance.proto
+++ b/core/akka-runtime/src/main/protobuf/process_instance.proto
@@ -25,6 +25,17 @@ message Initialized {
     optional SerializedData initial_state = 2;
 }
 
+message MetaDataAddedRecord {
+    optional string key = 1;
+    optional string value = 2;
+}
+
+message MetaDataAdded {
+    option (scalapb.message).extends = "com.ing.baker.runtime.akka.actor.serialization.BakerSerializable";
+
+    repeated MetaDataAddedRecord metaData = 1;
+}
+
 message TransitionFired {
     option (scalapb.message).extends = "com.ing.baker.runtime.akka.actor.serialization.BakerSerializable";
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
@@ -9,7 +9,7 @@ import com.ing.baker.il._
 import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome
 import com.ing.baker.runtime.akka.actor._
 import com.ing.baker.runtime.akka.actor.process_index.ProcessIndexProtocol._
-import com.ing.baker.runtime.akka.actor.process_instance.ProcessInstanceProtocol.{Initialized, InstanceState, Uninitialized}
+import com.ing.baker.runtime.akka.actor.process_instance.ProcessInstanceProtocol.{Initialized, InstanceState, MetaDataAdded, Uninitialized}
 import com.ing.baker.runtime.akka.actor.recipe_manager.RecipeManagerProtocol
 import com.ing.baker.runtime.akka.actor.recipe_manager.RecipeManagerProtocol.RecipeFound
 import com.ing.baker.runtime.akka.internal.CachingInteractionManager
@@ -333,6 +333,17 @@ class AkkaBaker private[runtime](config: AkkaBakerConfig) extends scaladsl.Baker
           Future.successful(result)
       }
     EventResolutions(futureReceived, futureCompleted)
+  }
+
+  override def addMetaData(recipeInstanceId: String, metadata: Map[String, String]): Future[Unit] = {
+    processIndexActor
+      .ask(AddRecipeInstanceMetaData(recipeInstanceId, metadata))(Timeout.durationToTimeout(config.timeouts.defaultInquireTimeout))
+      .flatMap {
+        case MetaDataAdded => Future.successful(())
+        case Uninitialized(id) => Future.failed(NoSuchProcessException(id))
+        case NoSuchProcess(id) => Future.failed(NoSuchProcessException(id))
+        case ProcessDeleted(id) => Future.failed(ProcessDeletedException(id))
+      }
   }
 
   /**

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
@@ -479,6 +479,11 @@ class ProcessIndex(recipeInstanceIdleTimeout: Option[FiniteDuration],
         }
       }
 
+    case AddRecipeInstanceMetaData(recipeInstanceId, metaData) =>
+      withActiveProcess(recipeInstanceId) { actorRef =>
+        actorRef.forward(AddMetaData(metaData))
+      }
+
     case GetProcessState(recipeInstanceId) =>
       withActiveProcess(recipeInstanceId) { actorRef => actorRef.forward(GetState) }
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProto.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProto.scala
@@ -360,6 +360,24 @@ object ProcessIndexProto {
         } yield ProcessEventResponse(recipeInstanceId)
     }
 
+  implicit def addRecipeInstanceMetaDataProto(implicit provider: AkkaSerializerProvider): ProtoMap[AddRecipeInstanceMetaData, protobuf.AddRecipeInstanceMetaData] =
+    new ProtoMap[AddRecipeInstanceMetaData, protobuf.AddRecipeInstanceMetaData] {
+
+      val companion = protobuf.AddRecipeInstanceMetaData
+
+      def toProto(a: AddRecipeInstanceMetaData): protobuf.AddRecipeInstanceMetaData =
+        protobuf.AddRecipeInstanceMetaData(
+          Some(a.recipeInstanceId),
+          a.metaData.map(record => {
+            protobuf.AddRecipeInstanceMetaDataRecord(Some(record._1), Some(record._2))}).toSeq)
+
+      def fromProto(message: protobuf.AddRecipeInstanceMetaData): Try[AddRecipeInstanceMetaData] =
+        for {
+          recipeInstanceId <- versioned(message.recipeInstanceId, "RecipeInstanceId")
+          metaData = message.metaData.map(record => (record.getKey -> record.getValue)).toMap
+        } yield AddRecipeInstanceMetaData(recipeInstanceId, metaData)
+    }
+
   implicit def getProcessStateProto: ProtoMap[GetProcessState, protobuf.GetProcessState] =
     new ProtoMap[GetProcessState, protobuf.GetProcessState] {
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProtocol.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProtocol.scala
@@ -30,6 +30,8 @@ object ProcessIndexProtocol {
 
   case class ResolveBlockedInteraction(recipeInstanceId: String, interactionName: String, output: EventInstance) extends ProcessIndexMessage
 
+  case class AddRecipeInstanceMetaData(recipeInstanceId: String, metaData: Map[String, String]) extends ProcessIndexMessage
+
   /**
     * Failure when attempting to resolve a blocked interaction, the event is not of valid type according with the recipe
     *

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstance.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstance.scala
@@ -209,6 +209,13 @@ class ProcessInstance[P: Identifiable, T: Identifiable, S, E](
           sender() ! instanceState
       }
 
+    case AddMetaData(metaData: Map[String, String]) =>
+      persistEvent(instance, ProcessInstanceEventSourcing.MetaDataAdded(metaData))(
+        eventSource.apply(instance)
+          .andThen {
+            case (instance) =>
+              sender() ! ProcessInstanceProtocol.MetaDataAdded
+              context become running(instance, scheduledRetries)})
 
     case event@TransitionFiredEvent(jobId, transitionId, correlationId, timeStarted, timeCompleted, consumed, produced, output) =>
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProto.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProto.scala
@@ -289,6 +289,22 @@ object ProcessInstanceProto {
         } yield  TransitionFailed(jobId, transitionId, message.correlationId, consume, input, reason, strategy)
     }
 
+  implicit def metaDataAddedProto(implicit ev0: AnyRefMapping): ProtoMap[MetaDataAdded.type, protobuf.MetaDataAdded] =
+    new ProtoMap[MetaDataAdded.type, protobuf.MetaDataAdded] {
+
+      val companion: GeneratedMessageCompanion[protobuf.MetaDataAdded] =
+        protobuf.MetaDataAdded
+
+      override def toProto(a: MetaDataAdded.type): protobuf.MetaDataAdded =
+        protobuf.MetaDataAdded()
+
+      override def fromProto(message: protobuf.MetaDataAdded): Try[MetaDataAdded.type] = {
+        Success(MetaDataAdded)
+      }
+    }
+
+
+
   implicit def transitionFiredProto(implicit ev0: AnyRefMapping): ProtoMap[TransitionFired, protobuf.TransitionFiredMessage] =
     new ProtoMap[TransitionFired, protobuf.TransitionFiredMessage] {
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
@@ -23,6 +23,11 @@ object ProcessInstanceProtocol {
     */
   case class Stop(delete: Boolean = false) extends Command
 
+  /**
+    * Command to add Ingredient
+    */
+  case class AddMetaData(metaData: Map[String, String]) extends Command
+
   object Initialize {
 
     def apply[P : Identifiable](marking: Marking[P]): Initialize = Initialize(marking.marshall, null)
@@ -72,6 +77,8 @@ object ProcessInstanceProtocol {
     * Indicates that the received FireTransition command with a specific correlation id was already received.
     */
   case class AlreadyReceived(correlationId: String) extends Response
+
+  case object MetaDataAdded extends Response
 
   object Initialized {
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/BakerTypedProtobufSerializer.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/BakerTypedProtobufSerializer.scala
@@ -100,7 +100,9 @@ object BakerTypedProtobufSerializer {
       forType[ProcessIndexProtocol.FireSensoryEventRejection.AlreadyReceived]
         .register("ProcessIndexProtocol.FireSensoryEventRejection.AlreadyReceived"),
       forType[ProcessIndexProtocol.FireSensoryEventRejection.FiringLimitMet]
-        .register("ProcessIndexProtocol.FireSensoryEventRejection.FiringLimitMet")
+        .register("ProcessIndexProtocol.FireSensoryEventRejection.FiringLimitMet"),
+      forType[ProcessIndexProtocol.AddRecipeInstanceMetaData]
+      .register("ProcessIndexProtocol.AddRecipeInstanceMetaData")
     )
 
   def processInstanceEntries(implicit ev0: AkkaSerializerProvider): List[BinarySerializable] =
@@ -133,12 +135,16 @@ object BakerTypedProtobufSerializer {
         .register("ProcessInstanceProtocol.TransitionFailed"),
       forType[ProcessInstanceProtocol.TransitionFired]
         .register("ProcessInstanceProtocol.TransitionFired"),
+      forType[ProcessInstanceProtocol.MetaDataAdded.type]
+        .register("ProcessInstanceProtocol.MetaDataAdded"),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFired]
         .register("TransitionFired")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFired)),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailed]
         .register("TransitionFailed")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailed)),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.Initialized]
-        .register("Initialized")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.Initialized))
+        .register("Initialized")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.Initialized)),
+      forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.MetaDataAdded]
+        .register("MetaDataAdded")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.MetaDataAdded)),
     )
 
   def recipeManagerEntries(implicit ev0: AkkaSerializerProvider): List[BinarySerializable] =

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
@@ -205,7 +205,8 @@ class RecipeRuntime(recipe: CompiledRecipe, interactionManager: InteractionManag
         eventStream.publish(InteractionStarted(timeStarted, recipe.name, recipe.recipeId, processState.recipeInstanceId, interaction.interactionName))
 
         // executes the interaction and obtain the (optional) output event
-        interactionManager.execute(interaction, input).map { interactionOutput =>
+        interactionManager.execute(interaction, input,
+          com.ing.baker.runtime.model.recipeinstance.RecipeInstanceState.getMetaDataFromIngredients(processState.ingredients)).map { interactionOutput =>
 
           // validates the event, throws a FatalInteraction exception if invalid
           RecipeRuntime.validateInteractionOutput(interaction, interactionOutput).foreach { validationError =>

--- a/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/BakerExecutionSpec.scala
+++ b/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/BakerExecutionSpec.scala
@@ -188,7 +188,20 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
           metaData.containsKey("key") && metaData.get("key") == "value2")
     }
 
-    "has not metaData if not given" in {
+    "allows empty metadata to an RecipeInstance" in {
+      for {
+        (baker, recipeId) <- setupBakerWithRecipe("MetaDataFour")
+        id = UUID.randomUUID().toString
+        _ <- baker.bake(recipeId, id)
+        _ <- baker.addMetaData(id, Map.empty)
+        ingredients: Map[String, Value] <- baker.getIngredients(id)
+        metaData = ingredients(RecipeInstanceMetaDataName).asMap(classOf[String], classOf[String])
+      } yield
+        assert(
+          metaData.size() == 0)
+    }
+
+    "has no metaData if not given" in {
       for {
         (baker, recipeId) <- setupBakerWithRecipe("MetaDataThree")
         id = UUID.randomUUID().toString

--- a/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/BakerExecutionSpec.scala
+++ b/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/BakerExecutionSpec.scala
@@ -3,7 +3,6 @@ package com.ing.baker.runtime.akka
 import java.net.MalformedURLException
 import java.util.concurrent.TimeUnit
 import java.util.{Optional, UUID}
-
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.persistence.inmemory.extension.{InMemoryJournalStorage, StorageExtension}
@@ -17,9 +16,10 @@ import com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAfterFail
 import com.ing.baker.recipe.scaladsl.{Event, Ingredient, Interaction, Recipe}
 import com.ing.baker.runtime.akka.internal.CachingInteractionManager
 import com.ing.baker.runtime.common.BakerException._
+import com.ing.baker.runtime.common.RecipeInstanceState.RecipeInstanceMetaDataName
 import com.ing.baker.runtime.common._
 import com.ing.baker.runtime.scaladsl.{Baker, EventInstance, InteractionInstance, InteractionInstanceInput, RecipeEventMetadata}
-import com.ing.baker.types.{CharArray, Int32, PrimitiveValue}
+import com.ing.baker.types.{CharArray, Int32, PrimitiveValue, Value}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.prometheus.client.CollectorRegistry
 import org.mockito.ArgumentMatchers.{any, anyString, argThat, eq => mockitoEq}
@@ -158,6 +158,43 @@ class BakerExecutionSpec extends BakerRuntimeTestBase {
           baker.bake(recipeId, id)
         }
       } yield succeed
+    }
+
+    "allows adding metadata to an RecipeInstance" in {
+      for {
+        (baker, recipeId) <- setupBakerWithRecipe("MetaDataOne")
+        id = UUID.randomUUID().toString
+        _ <- baker.bake(recipeId, id)
+        _ <- baker.addMetaData(id, Map.apply[String, String]("key" -> "value"))
+        _ <- baker.addMetaData(id, Map.apply[String, String]("key2" -> "value2"))
+        ingredients: Map[String, Value] <- baker.getIngredients(id)
+        metaData = ingredients(RecipeInstanceMetaDataName).asMap(classOf[String], classOf[String])
+      } yield assert(
+        metaData.containsKey("key") && metaData.get("key") == "value" &&
+        metaData.containsKey("key2") && metaData.get("key2") == "value2")
+    }
+
+    "allows updating metadata to an RecipeInstance" in {
+      for {
+        (baker, recipeId) <- setupBakerWithRecipe("MetaDataTwo")
+        id = UUID.randomUUID().toString
+        _ <- baker.bake(recipeId, id)
+        _ <- baker.addMetaData(id, Map.apply[String, String]("key" -> "value"))
+        _ <- baker.addMetaData(id, Map.apply[String, String]("key" -> "value2"))
+        ingredients: Map[String, Value] <- baker.getIngredients(id)
+        metaData = ingredients(RecipeInstanceMetaDataName).asMap(classOf[String], classOf[String])
+      } yield
+        assert(
+          metaData.containsKey("key") && metaData.get("key") == "value2")
+    }
+
+    "has not metaData if not given" in {
+      for {
+        (baker, recipeId) <- setupBakerWithRecipe("MetaDataThree")
+        id = UUID.randomUUID().toString
+        _ <- baker.bake(recipeId, id)
+        ingredients: Map[String, Value] <- baker.getIngredients(id)
+      } yield assert(!ingredients.contains(RecipeInstanceMetaDataName))
     }
 
     "throw a NoSuchProcessException" when {

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/common/Baker.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/common/Baker.scala
@@ -256,6 +256,14 @@ trait Baker[F[_]] extends LanguageApi {
   def fireEvent(recipeInstanceId: String, event: EventInstanceType, correlationId: language.Option[String]): EventResolutionsType
 
   /**
+    * This method is used to add metadata to your request. This will be added to the ingredients map in Baker.
+    * Since this is meant to be used as metadata this should not
+    * These cannot be ingredients already found in your recipe.
+    * @param metadata
+    */
+  def addMetaData(recipeInstanceId: String, metadata: language.Map[String, String]): F[Unit]
+
+  /**
     * Returns an index of all running processes.
     *
     * Can potentially return a partial index when baker runs in cluster mode

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/common/RecipeInstanceState.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/common/RecipeInstanceState.scala
@@ -3,6 +3,11 @@ package com.ing.baker.runtime.common
 import com.ing.baker.runtime.common.LanguageDataStructures.LanguageApi
 import com.ing.baker.types.Value
 
+object RecipeInstanceState {
+  //The name used for the RecipeInstanceMetaData ingredient
+  val RecipeInstanceMetaDataName = "RecipeInstanceMetaData"
+}
+
 /**
   * Holds the 'state' of a process instance.
   */

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/javadsl/Baker.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/javadsl/Baker.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.{BiConsumer, Consumer}
 import javax.annotation.Nonnull
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -395,4 +395,15 @@ class Baker(private val baker: scaladsl.Baker) extends common.Baker[CompletableF
       .toCompletableFuture
       .thenApply(_.asJava)
 
+  /**
+    * This method is used to add metadata to your request. This will be added to the ingredients map in Baker.
+    * Since this is meant to be used as metadata this should not
+    * These cannot be ingredients already found in your recipe.
+    *
+    * @param metadata
+    */
+  override def addMetaData(recipeInstanceId: String, metadata: java.util.Map[String, String]): CompletableFuture[Unit] = {
+    val x: Map[String, String] = metadata.asScala.toMap
+    toCompletableFuture(baker.addMetaData(recipeInstanceId, x))
+  }
 }

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/BakerF.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/BakerF.scala
@@ -261,6 +261,8 @@ abstract class BakerF[F[_]](implicit components: BakerComponents[F], effect: Con
   override def fireEvent(recipeInstanceId: String, event: EventInstance, correlationId: String): EventResolutionsType =
     fireEvent(recipeInstanceId, event, Some(correlationId))
 
+  override def addMetaData(recipeInstanceId: String, metadata: Map[String, String]): F[Unit] = throw new NotImplementedError()
+
   /**
     * Returns an index of all running processes.
     *
@@ -509,6 +511,8 @@ abstract class BakerF[F[_]](implicit components: BakerComponents[F], effect: Con
         mapK(self.resolveInteraction(recipeInstanceId, interactionName, event))
       override def stopRetryingInteraction(recipeInstanceId: String, interactionName: String): Future[Unit] =
         mapK(self.stopRetryingInteraction(recipeInstanceId, interactionName))
+      override def addMetaData(recipeInstanceId: String, metadata: Map[String, String]): Future[Unit] =
+        mapK(self.addMetaData(recipeInstanceId, metadata))
     }
 
 }

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/InteractionInstance.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/InteractionInstance.scala
@@ -22,7 +22,7 @@ import scala.runtime.ScalaRunTime
 abstract class InteractionInstance[F[_]] extends common.InteractionInstance[F] with ScalaApi {
   self =>
 
-  val run: Seq[IngredientInstance] => F[Option[EventInstance]]
+  val run: Seq[IngredientInstance]=> F[Option[EventInstance]]
 
   override type Event = EventInstance
 

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/InteractionManager.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/InteractionManager.scala
@@ -40,7 +40,7 @@ trait InteractionManager[F[_]] {
 
   def existsFor(interaction: InteractionTransition)(implicit sync: Sync[F]): F[Boolean] = findFor(interaction).map(_.nonEmpty)
 
-  def execute(interaction: InteractionTransition, input: Seq[IngredientInstance])(implicit sync: Sync[F], effect: MonadError[F, Throwable]): F[Option[EventInstance]] =
+  def execute(interaction: InteractionTransition, input: Seq[IngredientInstance], metadata: Option[Map[String, String]])(implicit sync: Sync[F], effect: MonadError[F, Throwable]): F[Option[EventInstance]] =
     findFor(interaction)
       .flatMap {
         case Some(implementation) => implementation.execute(input)

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstanceState.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstanceState.scala
@@ -7,11 +7,21 @@ import com.ing.baker.petrinet.api.{Marking, MultiSet}
 import com.ing.baker.runtime.scaladsl.{EventInstance, EventMoment}
 import com.ing.baker.il.petrinet._
 import com.ing.baker.petrinet.api._
-import com.ing.baker.types.Value
+import com.ing.baker.runtime.common.RecipeInstanceState.RecipeInstanceMetaDataName
+import com.ing.baker.types.{CharArray, MapType, Value}
 
 import scala.collection.immutable
 
 object RecipeInstanceState {
+
+  def getMetaDataFromIngredients(ingredients: Map[String, Value]): Option[Map[String, String]] = {
+    ingredients.get(RecipeInstanceMetaDataName).flatMap(value => {
+      if (value.isInstanceOf(MapType(CharArray)))
+        Some(value.as[Map[String, String]])
+      else
+        Option.empty
+    })
+  }
 
   def empty(recipeInstanceId: String, recipe: CompiledRecipe, createdOn: Long): RecipeInstanceState =
     RecipeInstanceState(

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/TransitionExecution.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/TransitionExecution.scala
@@ -145,7 +145,10 @@ private[recipeinstance] case class TransitionExecution(
     }
 
     def execute: F[Option[EventInstance]] =
-      components.interactions.execute(interactionTransition, buildInteractionInput)
+      components.interactions.execute(
+        interactionTransition,
+        buildInteractionInput,
+        com.ing.baker.runtime.model.recipeinstance.RecipeInstanceState.getMetaDataFromIngredients(ingredients))
 
     for {
       startTime <- timer.clock.realTime(MILLISECONDS)

--- a/http/baker-http-client/src/main/scala/com/ing/baker/http/client/scaladsl/BakerClient.scala
+++ b/http/baker-http-client/src/main/scala/com/ing/baker/http/client/scaladsl/BakerClient.scala
@@ -287,6 +287,12 @@ final class BakerClient( client: Client[IO],
     throw new NotImplementedError("Multiple events via HTTP API are not supported")
 
   /**
+    *
+    */
+  override def addMetaData(recipeInstanceId: String, metadata: Map[String,String]): Future[Unit] =
+    throw new NotImplementedError("AddMetaData not implemented for the BakerClient")
+
+  /**
     * Returns an index of all running processes.
     *
     * Can potentially return a partial index when baker runs in cluster mode

--- a/http/baker-http-dashboard/package.json
+++ b/http/baker-http-dashboard/package.json
@@ -36,7 +36,7 @@
     "@angular-eslint/eslint-plugin-template": "14.0.2",
     "@angular-eslint/schematics": "14.0.2",
     "@angular-eslint/template-parser": "14.0.2",
-    "@angular/cli": "^14.1.3",
+    "@angular/cli": "^14.2.3",
     "@angular/compiler-cli": "^14.0.6",
     "@angular/language-service": "^14.0.6",
     "@angular/localize": "^14.0.6",


### PR DESCRIPTION
This allows a user to set an RecipeInstanceMetaData that can be used in the InteractionManager. The original purpose is to support OpenTracing or similar context but this can be used for many differnt features.