### PR TITLE
Add new modules in baker_types to prepare for java17

### DIFF
--- a/core/baker-types/src/main/resources/reference.conf
+++ b/core/baker-types/src/main/resources/reference.conf
@@ -3,8 +3,15 @@ baker.types {
   "java.util.Set" = "com.ing.baker.types.modules.JavaModules$SetModule"
   "java.util.Map" = "com.ing.baker.types.modules.JavaModules$MapModule"
   "java.util.Optional" = "com.ing.baker.types.modules.JavaModules$OptionalModule"
+  "java.util.UUID" = "com.ing.baker.types.modules.UUIDModule"
 
   "java.lang.Enum" = "com.ing.baker.types.modules.EnumModule"
+  "java.lang.Record"  = "com.ing.baker.types.modules.RecordModule"
+
+  "java.time.DateTime" = "com.ing.baker.types.modules.JavaTimeModule"
+  "java.time.LocalDateTime" = "com.ing.baker.types.modules.JavaTimeModule"
+  "java.time.LocalDate" = "com.ing.baker.types.modules.JavaTimeModule"
+  "java.util.Date" = "com.ing.baker.types.modules.JavaTimeModule"
 
   "scala.collection.immutable.List" = "com.ing.baker.types.modules.ScalaModules$ListModule"
   "scala.collection.immutable.Set" = "com.ing.baker.types.modules.ScalaModules$SetModule"

--- a/core/baker-types/src/main/resources/reference.conf
+++ b/core/baker-types/src/main/resources/reference.conf
@@ -8,7 +8,6 @@ baker.types {
   "java.lang.Enum" = "com.ing.baker.types.modules.EnumModule"
   "java.lang.Record"  = "com.ing.baker.types.modules.RecordModule"
 
-  "java.time.DateTime" = "com.ing.baker.types.modules.JavaTimeModule"
   "java.time.LocalDateTime" = "com.ing.baker.types.modules.JavaTimeModule"
   "java.time.LocalDate" = "com.ing.baker.types.modules.JavaTimeModule"
 

--- a/core/baker-types/src/main/resources/reference.conf
+++ b/core/baker-types/src/main/resources/reference.conf
@@ -11,7 +11,6 @@ baker.types {
   "java.time.DateTime" = "com.ing.baker.types.modules.JavaTimeModule"
   "java.time.LocalDateTime" = "com.ing.baker.types.modules.JavaTimeModule"
   "java.time.LocalDate" = "com.ing.baker.types.modules.JavaTimeModule"
-  "java.util.Date" = "com.ing.baker.types.modules.JavaTimeModule"
 
   "scala.collection.immutable.List" = "com.ing.baker.types.modules.ScalaModules$ListModule"
   "scala.collection.immutable.Set" = "com.ing.baker.types.modules.ScalaModules$SetModule"

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/ClassModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/ClassModule.scala
@@ -1,6 +1,6 @@
 package com.ing.baker.types.modules
 
-import java.lang.reflect
+import java.lang.reflect.Type
 
 import com.ing.baker.types._
 
@@ -8,7 +8,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 abstract class ClassModule[T : TypeTag] extends TypeModule {
 
-  protected val clazz = mirror.runtimeClass(mirror.typeOf[T])
+  protected val clazz: Class[_] = mirror.runtimeClass(mirror.typeOf[T])
 
-  override def isApplicable(javaType: reflect.Type): Boolean = isAssignableToBaseClass(javaType, clazz)
+  override def isApplicable(javaType: Type): Boolean = isAssignableToBaseClass(javaType, clazz)
 }

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaModules.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaModules.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 
 object JavaModules {
 
-  class ListModule extends ClassModule[java.util.List[_]] {
+  class ListModule extends ClassModule[util.List[_]] {
 
     override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): ListType = {
       val entryType = context.readType(getTypeParameter(javaType, 0))

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
@@ -1,0 +1,39 @@
+package com.ing.baker.types.modules
+
+import com.ing.baker.types._
+
+import java.time._
+import java.util.{Date => JDate}
+import scala.annotation.nowarn
+
+/**
+ * Add support for Java time objects
+ **/
+class JavaTimeModule extends TypeModule {
+
+  override def isApplicable(javaType: java.lang.reflect.Type): Boolean =
+      isAssignableToBaseClass(javaType, classOf[LocalDateTime]) ||
+      isAssignableToBaseClass(javaType, classOf[LocalDate])
+
+  override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = Date
+
+  @nowarn
+  override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any =
+    (value, javaType) match {
+      case (NullValue, _) => null
+      case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[JDate].isAssignableFrom(clazz) =>
+        new JDate(millis)
+      case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[LocalDateTime].isAssignableFrom(clazz) =>
+        LocalDateTime.from(Instant.ofEpochMilli(millis))
+      case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[LocalDate].isAssignableFrom(clazz) =>
+        LocalDate.from(Instant.ofEpochMilli(millis))
+    }
+
+  override def fromJava(context: TypeAdapter, obj: Any): Value =
+    obj match {
+      case date: JDate => PrimitiveValue(date.getTime)
+      case localDate: LocalDate => PrimitiveValue(localDate.atStartOfDay.atZone(ZoneId.systemDefault()).toInstant
+        .toEpochMilli)
+      case localDateTime: LocalDateTime => PrimitiveValue(localDateTime.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli)
+    }
+}

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
@@ -3,7 +3,6 @@ package com.ing.baker.types.modules
 import com.ing.baker.types._
 
 import java.time._
-import scala.annotation.nowarn
 
 /**
  * Add support for Java time objects
@@ -16,7 +15,6 @@ class JavaTimeModule extends TypeModule {
 
   override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = Date
 
-  @nowarn
   override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any =
     (value, javaType) match {
       case (NullValue, _) => null

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/JavaTimeModule.scala
@@ -3,7 +3,6 @@ package com.ing.baker.types.modules
 import com.ing.baker.types._
 
 import java.time._
-import java.util.{Date => JDate}
 import scala.annotation.nowarn
 
 /**
@@ -21,8 +20,6 @@ class JavaTimeModule extends TypeModule {
   override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any =
     (value, javaType) match {
       case (NullValue, _) => null
-      case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[JDate].isAssignableFrom(clazz) =>
-        new JDate(millis)
       case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[LocalDateTime].isAssignableFrom(clazz) =>
         LocalDateTime.from(Instant.ofEpochMilli(millis))
       case (PrimitiveValue(millis: Long), clazz: Class[_]) if classOf[LocalDate].isAssignableFrom(clazz) =>
@@ -31,7 +28,6 @@ class JavaTimeModule extends TypeModule {
 
   override def fromJava(context: TypeAdapter, obj: Any): Value =
     obj match {
-      case date: JDate => PrimitiveValue(date.getTime)
       case localDate: LocalDate => PrimitiveValue(localDate.atStartOfDay.atZone(ZoneId.systemDefault()).toInstant
         .toEpochMilli)
       case localDateTime: LocalDateTime => PrimitiveValue(localDateTime.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli)

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/PojoModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/PojoModule.scala
@@ -12,7 +12,7 @@ class PojoModule extends TypeModule {
   override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = {
 
     val pojoClass = getBaseClass(javaType)
-    val fields = pojoClass.getDeclaredFields.toIndexedSeq.filterNot(f => f.isSynthetic || Modifier.isStatic(f.getModifiers))
+    val fields = pojoClass.getDeclaredFields.toIndexedSeq.filterNot(f => f.isSynthetic || Modifier.isStatic(f.getModifiers) || Modifier.isFinal(f.getModifiers))
     val ingredients = fields.map(f => RecordField(f.getName, context.readType(f.getGenericType)))
     RecordType(ingredients)
   }
@@ -35,8 +35,9 @@ class PojoModule extends TypeModule {
       fields.foreach { f =>
         entries.get(f.getName).foreach { entryValue =>
 
-          val fieldType = f.getGenericType()
+          val fieldType = f.getGenericType
           try {
+            //this is an illegal action with Java 17 when a record is used, or any final fields
             val value = context.toJava(entryValue, fieldType)
             f.setAccessible(true)
             f.set(pojoInstance, value)

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/PojoModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/PojoModule.scala
@@ -12,7 +12,7 @@ class PojoModule extends TypeModule {
   override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = {
 
     val pojoClass = getBaseClass(javaType)
-    val fields = pojoClass.getDeclaredFields.toIndexedSeq.filterNot(f => f.isSynthetic || Modifier.isStatic(f.getModifiers) || Modifier.isFinal(f.getModifiers))
+    val fields = pojoClass.getDeclaredFields.toIndexedSeq.filterNot(f => f.isSynthetic || Modifier.isStatic(f.getModifiers))
     val ingredients = fields.map(f => RecordField(f.getName, context.readType(f.getGenericType)))
     RecordType(ingredients)
   }

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/PrimitiveModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/PrimitiveModule.scala
@@ -4,24 +4,25 @@ import java.lang.reflect.ParameterizedType
 
 import com.ing.baker.types
 import com.ing.baker.types._
+import java.lang.reflect.{Type => JType}
 
 class PrimitiveModule extends TypeModule {
 
-  def isByteArray(javaType: java.lang.reflect.Type) = javaType match {
+  private def isByteArray(javaType: JType) = javaType match {
     case clazz: Class[_] =>
       clazz == classOf[Array[Byte]]
     case t: ParameterizedType =>
       classOf[scala.Array[_]].isAssignableFrom(getBaseClass(t)) && classOf[Byte].isAssignableFrom(getBaseClass(t.getActualTypeArguments()(0)))
   }
 
-  override def isApplicable(javaType: java.lang.reflect.Type): Boolean = {
+  override def isApplicable(javaType: JType): Boolean = {
     javaType match {
       case clazz: Class[_] => primitiveMappings.contains(clazz)
       case other           => isByteArray(other)
     }
   }
 
-  override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = {
+  override def readType(context: TypeAdapter, javaType: JType): Type = {
     javaType match {
       case clazz: Class[_] => primitiveMappings(clazz)
       case other if isByteArray(other) => types.ByteArray
@@ -31,7 +32,7 @@ class PrimitiveModule extends TypeModule {
 
   override def fromJava(context: TypeAdapter, obj: Any): Value = PrimitiveValue(obj)
 
-  override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any = {
+  override def toJava(context: TypeAdapter, value: Value, javaType: JType): Any = {
 
     (value, javaType) match {
       case (p @ PrimitiveValue(obj), clazz: Class[_]) if p.isAssignableTo(clazz) => obj

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/RecordModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/RecordModule.scala
@@ -1,0 +1,64 @@
+package com.ing.baker.types.modules
+
+import com.ing.baker.types._
+
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
+import java.lang.reflect.{Type => JType}
+
+class RecordModule extends TypeModule {
+
+  private val LOOKUP = MethodHandles.lookup()
+  override def isApplicable(javaType: JType): Boolean = {
+    try {
+      javaType.getClass.isRecord
+    }
+    catch {
+      //if this happens, we don't use Java 16+
+      case _: Exception => false
+    }
+  }
+
+  override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = {
+    val recordType = getBaseClass(javaType)
+    val ingredients = recordType.getRecordComponents.map(f => RecordField(f.getName, context.readType(f.getGenericType)))
+    RecordType(ingredients)
+  }
+
+  override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any = value match {
+    case NullValue => null
+    case RecordValue(entries) =>
+      val recordType = getBaseClass(javaType)
+
+      //
+      val recordValues = recordType.getRecordComponents
+        .map(r => {
+            val value = entries(r.getName)
+            val fieldType = r.getGenericType
+            try {
+              return context.toJava(value, fieldType)
+            } catch {
+              case e: Exception => throw new IllegalStateException(s"Failed parse field '${r.getName}' as type: $fieldType", e)
+            }
+        })
+
+      try {
+        val paramTypes = recordType.getRecordComponents.map(r => r.getType)
+        val MH_canonicalConstructor = LOOKUP.findConstructor(recordType, methodType(classOf[Unit], paramTypes)).asType(methodType(classOf[AnyRef], paramTypes))
+        MH_canonicalConstructor.invokeWithArguments(recordValues)
+
+      } catch {
+        case _: Exception =>
+          throw new RuntimeException("Could not construct type (" + recordType.getName + ")")
+      }
+
+    case _=>
+      throw new IllegalArgumentException(s"Unsupported value: $value")
+  }
+
+  override def fromJava(context: TypeAdapter, pojo: Any): Value = {
+    val entries: Map[String, Value] = pojo.getClass.getRecordComponents
+      .map(f => f.getName -> context.fromJava(f.getAccessor.invoke(pojo))).toMap //is order guaranteed?
+    RecordValue(entries)
+  }
+}

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/RecordModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/RecordModule.scala
@@ -44,8 +44,8 @@ class RecordModule extends TypeModule {
 
       try {
         val paramTypes = recordType.getRecordComponents.map(r => r.getType)
-        val MH_canonicalConstructor = LOOKUP.findConstructor(recordType, methodType(classOf[Unit], paramTypes)).asType(methodType(classOf[AnyRef], paramTypes))
-        MH_canonicalConstructor.invokeWithArguments(recordValues)
+        val canonicalConstructor = LOOKUP.findConstructor(recordType, methodType(classOf[Unit], paramTypes)).asType(methodType(classOf[AnyRef], paramTypes))
+        canonicalConstructor.invokeWithArguments(recordValues)
 
       } catch {
         case _: Exception =>

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/ScalaModules.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/ScalaModules.scala
@@ -4,19 +4,19 @@ import com.ing.baker.types._
 
 import java.lang.reflect.ParameterizedType
 import scala.annotation.nowarn
-import java.lang.reflect
+import java.lang.reflect.{Type => JType}
 
 object ScalaModules {
 
   class ListModule extends ClassModule[List[_]] {
 
-    override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type) = {
+    override def readType(context: TypeAdapter, javaType: JType): ListType = {
       val entryType = context.readType(getTypeParameter(javaType, 0))
       ListType(entryType)
     }
 
     @nowarn
-    override  def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type) = value match {
+    override def toJava(context: TypeAdapter, value: Value, javaType: JType): List[Any] = value match {
       case NullValue => null
       case ListValue(entries) if isApplicable(javaType) =>
         val entryType = getTypeParameter(javaType, 0)
@@ -30,13 +30,13 @@ object ScalaModules {
 
   class SetModule extends ClassModule[Set[_]] {
 
-    override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type) = {
+    override def readType(context: TypeAdapter, javaType: JType): ListType = {
       val entryType = context.readType(getTypeParameter(javaType, 0))
       ListType(entryType)
     }
 
     @nowarn
-    override  def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type) = value match {
+    override def toJava(context: TypeAdapter, value: Value, javaType: JType): Set[Any] = value match {
       case NullValue => null
       case ListValue(entries) if isApplicable(javaType) =>
         val entryType = getTypeParameter(javaType, 0)
@@ -50,13 +50,13 @@ object ScalaModules {
 
   class MapModule extends ClassModule[Map[_, _]] {
 
-    override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type) = {
+    override def readType(context: TypeAdapter, javaType: JType): MapType = {
       val entryType = context.readType(getTypeParameter(javaType, 1))
       MapType(entryType)
     }
 
     @nowarn
-    override  def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type) = value match {
+    override def toJava(context: TypeAdapter, value: Value, javaType: JType): Map[String, Any] = value match {
       case NullValue => null
       case RecordValue(entries) if classOf[Map[_,_]].isAssignableFrom(getBaseClass(javaType)) =>
         val keyType = getTypeParameter(javaType, 0)
@@ -71,21 +71,21 @@ object ScalaModules {
 
     def fromJava(context: TypeAdapter, obj: Any): Value = obj match {
       case map: Map[_, _] =>
-        val entries: Map[String, Value] = map.map { case (key, obj) => key.asInstanceOf[String] -> context.fromJava(obj) }.toMap
+        val entries: Map[String, Value] = map.map { case (key, obj) => key.asInstanceOf[String] -> context.fromJava(obj) }
         RecordValue(entries)
     }
   }
 
   class OptionModule extends ClassModule[Option[_]] {
 
-    override def readType(context: TypeAdapter, javaType: reflect.Type): Type = javaType match {
+    override def readType(context: TypeAdapter, javaType: JType): Type = javaType match {
       case clazz: ParameterizedType if classOf[scala.Option[_]].isAssignableFrom(getBaseClass(clazz)) =>
         val entryType = context.readType(clazz.getActualTypeArguments()(0))
         OptionType(entryType)
     }
 
     @nowarn
-    override def toJava(context: TypeAdapter, value: Value, javaType: reflect.Type): Any = (value, javaType) match {
+    override def toJava(context: TypeAdapter, value: Value, javaType: JType): Any = (value, javaType) match {
       case (_, generic: ParameterizedType) if classOf[Option[_]].isAssignableFrom(getBaseClass(generic.getRawType)) =>
         val optionType = generic.getActualTypeArguments()(0)
         value match {
@@ -104,6 +104,3 @@ object ScalaModules {
     }
   }
 }
-
-
-

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/UUIDModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/UUIDModule.scala
@@ -1,0 +1,38 @@
+package com.ing.baker.types.modules
+
+import com.ing.baker.types._
+
+import java.lang.reflect
+
+import scala.annotation.nowarn
+
+class UUIDModule extends TypeModule {
+
+  override def isApplicable(javaType: reflect.Type): Boolean = javaType match {
+    case clazz: Class[_] if clazz.isAssignableFrom(classOf[java.util.UUID]) => true
+    case _ => false
+  }
+
+  /**
+    * Attempts to convert a value to a desired java type.
+    *
+    * @param value    The value
+    * @param javaType The desired java type.
+    *
+    * @return An instance of the java type.
+    */
+  @nowarn
+  override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any = {
+    (value, javaType) match {
+      case (NullValue, _) => null
+      case (PrimitiveValue(option: String), clazz: Class[_]) if clazz.isAssignableFrom(classOf[java.util.UUID]) =>
+        java.util.UUID.fromString(option)
+    }
+  }
+
+  override def readType(context: TypeAdapter, javaType: java.lang.reflect.Type): Type = CharArray
+
+
+  override def fromJava(context: TypeAdapter, obj: Any): Value = PrimitiveValue(obj.toString)
+
+}

--- a/core/baker-types/src/main/scala/com/ing/baker/types/modules/UUIDModule.scala
+++ b/core/baker-types/src/main/scala/com/ing/baker/types/modules/UUIDModule.scala
@@ -25,8 +25,8 @@ class UUIDModule extends TypeModule {
   override def toJava(context: TypeAdapter, value: Value, javaType: java.lang.reflect.Type): Any = {
     (value, javaType) match {
       case (NullValue, _) => null
-      case (PrimitiveValue(option: String), clazz: Class[_]) if clazz.isAssignableFrom(classOf[java.util.UUID]) =>
-        java.util.UUID.fromString(option)
+      case (PrimitiveValue(uuid: String), clazz: Class[_]) if clazz.isAssignableFrom(classOf[java.util.UUID]) =>
+        java.util.UUID.fromString(uuid)
     }
   }
 

--- a/core/baker-types/src/test/scala/com/ing/baker/types/modules/PrimitiveModuleSpec.scala
+++ b/core/baker-types/src/test/scala/com/ing/baker/types/modules/PrimitiveModuleSpec.scala
@@ -12,6 +12,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.scalacheck.Checkers
 
 import java.lang
+import java.util.UUID
 import scala.annotation.nowarn
 import scala.reflect.runtime.universe.TypeTag
 
@@ -37,7 +38,7 @@ object PrimitiveModuleSpec {
 
 class PrimitiveModuleSpec extends AnyWordSpecLike with Matchers with Checkers {
 
-  "The primivite module" should {
+  "The primitive module" should {
 
     "correctly parse all the supported primitive types" in {
 
@@ -57,6 +58,7 @@ class PrimitiveModuleSpec extends AnyWordSpecLike with Matchers with Checkers {
       readJavaType[BigDecimal] shouldBe types.FloatBig
       readJavaType[java.math.BigDecimal] shouldBe types.FloatBig
       readJavaType[Array[Byte]] shouldBe types.ByteArray
+      readJavaType[UUID] shouldBe types.CharArray
     }
 
     "read/write all supported primitive types" in {


### PR DESCRIPTION
Add Java 17 support to add new modules for java.time.*, java.util.UUID and java.lang.Record

In Java17 it's not allowed anymore to set values to final fields, instead new modules are created for classes like java.time.*, java.util.UUID and java records to instantiate the object in a non reflective way.

Modules can be extended to add new types.

JavaTimeModule maps LocalDate and LocalDateTime to an epochMillis long value, (and back)
UUIDModule converts the UUID type into a string (and back)
Record type uses the new Java 17 records to read and instantiate a record using Class.isRecord (will fail on java 11) and uses getRecordComponents()[].
