### PR TITLE
Fixed output ingredient rename example/doc for Java

### DIFF
--- a/examples/docs-code-snippets/src/main/java/examples/java/recipes/RecipeWithEventTransformation.java
+++ b/examples/docs-code-snippets/src/main/java/examples/java/recipes/RecipeWithEventTransformation.java
@@ -10,8 +10,9 @@ public class RecipeWithEventTransformation {
     public final static Recipe recipe = new Recipe("example")
         .withInteractions(
             InteractionDescriptor.of(ShipOrder.class)
-                .withEventTransformation(OrderPlaced.class, "OrderCreated")
-                .renameRequiredIngredient("customerId", "userId")
-                .renameRequiredIngredient("productIds", "skus")
+                .withEventTransformation(OrderPlaced.class, "OrderCreated",
+                        Map.of("customerId", "userId",
+                               "productIds", "skus")
+                )
         );
 }

--- a/examples/docs-code-snippets/src/main/java/examples/java/recipes/RecipeWithEventTransformation.java
+++ b/examples/docs-code-snippets/src/main/java/examples/java/recipes/RecipeWithEventTransformation.java
@@ -5,6 +5,8 @@ import com.ing.baker.recipe.javadsl.Recipe;
 import examples.java.events.OrderPlaced;
 import examples.java.interactions.ShipOrder;
 
+import java.util.Map;
+
 public class RecipeWithEventTransformation {
 
     public final static Recipe recipe = new Recipe("example")

--- a/http/baker-http-dashboard/package.json
+++ b/http/baker-http-dashboard/package.json
@@ -36,7 +36,7 @@
     "@angular-eslint/eslint-plugin-template": "14.0.2",
     "@angular-eslint/schematics": "14.0.2",
     "@angular-eslint/template-parser": "14.0.2",
-    "@angular/cli": "^14.2.12",
+    "@angular/cli": "^14.2.13",
     "@angular/compiler-cli": "^14.0.6",
     "@angular/language-service": "^14.0.6",
     "@angular/localize": "^14.0.6",


### PR DESCRIPTION
Fixed the output ingredient rename in Java. In the example it was renaming input ingredients