### PR TITLE
Kotlin DSL patch

### DIFF
--- a/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
+++ b/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
@@ -8,16 +8,14 @@ import com.ing.baker.runtime.javadsl.InteractionInstance
 import com.ing.baker.runtime.javadsl.InteractionInstanceInput
 import com.ing.baker.types.Converters
 import scala.collection.immutable.Map
-import java.lang.reflect.Type
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.CompletableFuture
-import kotlin.reflect.KParameter
 import kotlin.reflect.full.createType
 import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.reflect
 
-inline fun <reified T1, reified R> functionInteractionInstance(
+inline fun <reified T1, R> functionInteractionInstance(
     name: String,
     noinline function: (T1) -> R
 ): InteractionInstance {
@@ -72,7 +70,7 @@ inline fun <reified T1, reified R> functionInteractionInstance(
     }
 }
 
-inline fun <reified T1, reified T2, reified R> functionInteractionInstance(
+inline fun <reified T1, reified T2, R> functionInteractionInstance(
     name: String,
     noinline function: (T1, T2) -> R
 ): InteractionInstance {
@@ -129,7 +127,7 @@ inline fun <reified T1, reified T2, reified R> functionInteractionInstance(
     }
 }
 
-inline fun <reified T1, reified T2, reified T3, reified R> functionInteractionInstance(
+inline fun <reified T1, reified T2, reified T3, R> functionInteractionInstance(
     name: String,
     noinline function: (T1, T2, T3) -> R
 ): InteractionInstance {

--- a/core/baker-interface-kotlin/src/test/kotlin/FunctionInteractionInstanceTest.kt
+++ b/core/baker-interface-kotlin/src/test/kotlin/FunctionInteractionInstanceTest.kt
@@ -12,4 +12,12 @@ class FunctionInteractionInstanceTest {
 
         assertEquals(interaction.name(), "\$SieveInteraction\$test")
     }
+
+    @Test
+    fun `should handle function interaction list`() {
+        val func = { test: String -> listOf("") }
+        val interaction = functionInteractionInstance("test", func)
+
+        assertEquals(interaction.name(), "\$SieveInteraction\$test")
+    }
 }

--- a/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -17,6 +17,7 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.reflect
+import kotlin.reflect.typeOf
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
@@ -100,36 +101,36 @@ class RecipeBuilder(private val name: String) {
 
 
     /**
-     * Registers an sieve [T1, T2, R] to the recipe.
+     * Registers a sieve [T1, T2, R] to the recipe.
      */
     inline fun <reified T1,reified R> ingredient(name: String, noinline function: (T1) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
         val ingredients = listOf(T1::class)
             .zip(parameters)
             .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
-        addSieve(name, ingredients, R::class.createType().javaType, function)
+        addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 
     /**
-     * Registers an sieve [T1, T2, R] to the recipe.
+     * Registers a sieve [T1, T2, R] to the recipe.
      */
     inline fun <reified T1, reified T2, reified R> ingredient(name: String, noinline function: (T1, T2) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
         val ingredients = listOf(T1::class, T2::class)
             .zip(parameters)
             .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
-        addSieve(name, ingredients, R::class.createType().javaType, function)
+        addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 
     /**
-     * Registers an sieve [T1, T2, R] to the recipe.
+     * Registers a sieve [T1, T2, R] to the recipe.
      */
     inline fun <reified T1, reified T2, reified T3, reified R> ingredient(name: String, noinline function: (T1, T2, T3) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
         val ingredients = listOf(T1::class, T2::class, T3::class)
             .zip(parameters)
             .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
-        addSieve(name, ingredients, R::class.createType().javaType, function)
+        addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 
     fun addSieve(name:String, ingredients:List<Ingredient>, returnType:Type, function:Any){


### PR DESCRIPTION
Kotlin DSL using createType().javaType on reified generic instance sometimes fail, replaced with typeOf<...>() function which was created for this specific scenario.

Additionally added a test for the functionInteractionInstance() utility method, removed reified keyword where not needed.