### PR TITLE
scala-steward non major library upgrades grouped

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ lazy val `baker-test`: Project = project.in(file("core/baker-test"))
     ) ++ testDeps(scalaTest, logback,
       "io.altoo" %% "akka-kryo-serialization" % "2.4.3",
       "junit" % "junit" % "4.13.2",
-      "org.scalatestplus" %% "junit-4-13" % "3.2.12.0"
+      "org.scalatestplus" %% "junit-4-13" % "3.2.19.0"
     )
   ).dependsOn(`baker-interface`, testScope(`baker-akka-runtime`), testScope(`baker-recipe-compiler`))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.14"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.1"
-  val scalaCheckPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0"
+  val scalaCheckPlus = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.18.0"
   val scalaCheckPlusMockito = "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
   val mockServer = "org.mock-server" % "mockserver-netty" % "5.14.0"
   val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"
-  val junitJupiter = "org.junit.jupiter" % "junit-jupiter-engine" % "5.9.3"
+  val junitJupiter = "org.junit.jupiter" % "junit-jupiter-engine" % "5.11.0"
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,7 +124,7 @@ object Dependencies {
   val objenisis = "org.objenesis" % "objenesis" % "3.2"
   val jodaTime = "joda-time" % "joda-time" % "2.12.5"
   val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.7"
-  val logback = "ch.qos.logback" % "logback-classic" % "1.4.6"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.4.14"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.0"
   val scalaCheckPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,7 +80,7 @@ object Dependencies {
   val cassandraUnit = "org.cassandraunit" % "cassandra-unit" % "4.3.1.0"
   val cassandraDriverCore = "com.datastax.oss" % "java-driver-core" % "4.15.0"
   val cassandraDriverQueryBuilder = "com.datastax.oss" % "java-driver-query-builder" % "4.15.0"
-  val cassandraDriverMetrics = "io.dropwizard.metrics" % "metrics-jmx" % "4.2.18"
+  val cassandraDriverMetrics = "io.dropwizard.metrics" % "metrics-jmx" % "4.2.27"
 
   val skuber = "io.skuber" %% "skuber" % "2.6.7"
   val play = "com.typesafe.play" %% "play-json" % "2.9.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val http4sVersion = "0.21.34"
   val fs2Version = "2.5.10"
   val circeVersion = "0.14.2"
-  val mockitoScalaVersion = "1.17.14"
+  val mockitoScalaVersion = "1.17.37"
   val catsEffectVersion = "2.5.5"
   val catsCoreVersion = "2.8.0"
   val scalapbVersion = scalapb.compiler.Version.scalapbVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,7 +122,7 @@ object Dependencies {
   val typeSafeConfig = "com.typesafe" % "config" % "1.4.2"
 
   val objenisis = "org.objenesis" % "objenesis" % "3.2"
-  val jodaTime = "joda-time" % "joda-time" % "2.12.5"
+  val jodaTime = "joda-time" % "joda-time" % "2.12.7"
   val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.7"
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.6"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,7 @@ object Dependencies {
   val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.7"
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.6"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.0"
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.1"
   val scalaCheckPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0"
   val scalaCheckPlusMockito = "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -141,7 +141,7 @@ object Dependencies {
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1"
   val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.15.1"
   val jawnParser = "org.typelevel" %% "jawn-parser" % "1.4.0"
-  val nettyHandler = "io.netty" % "netty-handler" % "4.1.92.Final"
+  val nettyHandler = "io.netty" % "netty-handler" % "4.1.112.Final"
 
   private val bouncycastleVersion = "1.70"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
   val akkaClusterBoostrap = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion
   val akkaDiscoveryKube = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % akkaManagementVersion
 
-  val kafkaClient = "org.apache.kafka" % "kafka-clients" % "3.4.0"
+  val kafkaClient = "org.apache.kafka" % "kafka-clients" % "3.4.1"
   val fs2Core = "co.fs2" %% "fs2-core" % fs2Version
   val fs2Io = "co.fs2" %% "fs2-io" % fs2Version
   val fs2kafka = "com.github.fd4s" %% "fs2-kafka" % "1.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -115,7 +115,7 @@ object Dependencies {
 
   val scalapbRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf"
 
-  val protobufJava = "com.google.protobuf" % "protobuf-java" % "3.22.2"
+  val protobufJava = "com.google.protobuf" % "protobuf-java" % "3.22.5"
 
   val betterFiles = "com.github.pathikrit" %% "better-files" % "3.9.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
 
   val scalaJava8Compat100 = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
 
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
   val mockServer = "org.mock-server" % "mockserver-netty" % "5.14.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -136,7 +136,7 @@ object Dependencies {
   val springCore = "org.springframework" % "spring-core" % springVersion
   val springBootStarter = "org.springframework.boot" % "spring-boot-starter" % springBootVersion
 
-  val snakeYaml = "org.yaml" % "snakeyaml" % "2.0"
+  val snakeYaml = "org.yaml" % "snakeyaml" % "2.2"
 
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1"
   val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.15.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
   val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
-  val mockServer = "org.mock-server" % "mockserver-netty" % "5.14.0"
+  val mockServer = "org.mock-server" % "mockserver-netty" % "5.15.0"
   val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"
   val junitJupiter = "org.junit.jupiter" % "junit-jupiter-engine" % "5.9.3"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -148,7 +148,7 @@ object Dependencies {
   val bouncyCastleBcprov = "org.bouncycastle" % "bcprov-jdk15on" % bouncycastleVersion
   val bouncyCastleBcpkix = "org.bouncycastle" % "bcpkix-jdk15on" % bouncycastleVersion
 
-  val guava = "com.google.guava" % "guava" % "31.1-jre"
+  val guava = "com.google.guava" % "guava" % "33.3.0-jre"
 
   val kotlinXCoroutinesCore = "org.jetbrains.kotlinx" % "kotlinx-coroutines-core" % "1.7.1" pomOnly()
   val kotlinXCoroutinesJdk8 = "org.jetbrains.kotlinx" % "kotlinx-coroutines-jdk8" % "1.7.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val catsEffectVersion = "2.5.5"
   val catsCoreVersion = "2.8.0"
   val scalapbVersion = scalapb.compiler.Version.scalapbVersion
-  val springVersion = "5.3.27"
+  val springVersion = "5.3.39"
   val springBootVersion = "2.6.1"
 
   val akkaInmemoryJournal = ("com.github.dnvriend" %% "akka-persistence-inmemory" % "2.5.15.2")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -140,7 +140,7 @@ object Dependencies {
 
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1"
   val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.15.1"
-  val jawnParser = "org.typelevel" %% "jawn-parser" % "1.4.0"
+  val jawnParser = "org.typelevel" %% "jawn-parser" % "1.6.0"
   val nettyHandler = "io.netty" % "netty-handler" % "4.1.92.Final"
 
   private val bouncycastleVersion = "1.70"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -138,8 +138,8 @@ object Dependencies {
 
   val snakeYaml = "org.yaml" % "snakeyaml" % "2.0"
 
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1"
-  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.15.1"
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.4"
+  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4"
   val jawnParser = "org.typelevel" %% "jawn-parser" % "1.4.0"
   val nettyHandler = "io.netty" % "netty-handler" % "4.1.92.Final"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,7 +111,7 @@ object Dependencies {
   val paranamer = "com.thoughtworks.paranamer" % "paranamer" % "2.8"
   val findbugs = "com.google.code.findbugs" % "jsr305" % "1.3.9"
 
-  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.10.0"
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
 
   val scalapbRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -123,7 +123,7 @@ object Dependencies {
 
   val objenisis = "org.objenesis" % "objenesis" % "3.2"
   val jodaTime = "joda-time" % "joda-time" % "2.12.5"
-  val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.7"
+  val slf4jApi = "org.slf4j" % "slf4j-api" % "2.0.16"
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.6"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.17.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val akkaPersistenceCassandraVersion = "1.0.6"
   val akkaHttpVersion = "10.2.9"
   val http4sVersion = "0.21.34"
-  val fs2Version = "2.5.10"
+  val fs2Version = "2.5.12"
   val circeVersion = "0.14.2"
   val mockitoScalaVersion = "1.17.14"
   val catsEffectVersion = "2.5.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,4 +24,4 @@ addSbtPlugin("no.arktekk.sbt" % "aether-deploy" % "0.27.0")
 
 addSbtPlugin("community.flock.sbt" % "sbt-kotlin-plugin" % "3.0.1")
 
-libraryDependencies += "org.slf4j" % "slf4j-nop" % "2.0.7"
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "2.0.16"


### PR DESCRIPTION
All the following updates grouped together in this PR:

Update scalacheck dependency to version 3.2.18.0 compatible with scalacheck 1.17
Update guava to 33.3.0-jre
Update metrics-jmx to 4.2.27
Update junit-jupiter-engine to 5.11.0
Update slf4j-api, slf4j-nop to 2.0.16
Update netty-handler to 4.1.112.Final
Update junit-4-13 to 3.2.19.0
Update scalatest to 3.2.19
Update mockito-scala, ... to 1.17.37
Update jawn-parser to 1.6.0
Update fs2-core, fs2-io to 2.5.12
Update scalacheck to 1.17.1
Update scala-collection-compat to 2.12.0
Update snakeyaml to 2.2
Update mockserver-netty to 5.15.0
Update joda-time to 2.12.7
Update jackson-core, jackson-databind to 2.15.4
Update spring-context, spring-core to 5.3.39
Update protobuf-java to 3.22.5
Update kafka-clients to 3.4.1
Update logback-classic to 1.4.14