### PR TITLE
Update azure-build.yaml to trigger pipeline for each PR created against master branch

### DIFF
--- a/azure-build.yaml
+++ b/azure-build.yaml
@@ -1,9 +1,5 @@
-trigger:
-  batch: true
-  branches:
-    include:
-      - master
-      - feature*
+pr:
+- master
 
 parameters:
   - name: ForcePublish


### PR DESCRIPTION
Current setup does not trigger the pipeline for the PRs created by scala-steward, or any other external fork. This change fixes the config so that all PRs against master branch will trigger pipeline automatically.