### PR TITLE
Type handling in Kotlin DSL still had a bug

### DIFF
--- a/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
+++ b/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
@@ -21,7 +21,7 @@ inline fun <reified T1, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        typeOf<T1>().javaType
+        javaTypeOf<T1>()
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")
@@ -76,8 +76,8 @@ inline fun <reified T1, reified T2, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        typeOf<T1>().javaType,
-        typeOf<T2>().javaType
+        javaTypeOf<T1>(),
+        javaTypeOf<T2>()
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")
@@ -133,9 +133,9 @@ inline fun <reified T1, reified T2, reified T3, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        typeOf<T1>().javaType,
-        typeOf<T2>().javaType,
-        typeOf<T3>().javaType,
+        javaTypeOf<T1>(),
+        javaTypeOf<T2>(),
+        javaTypeOf<T3>()
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")
@@ -185,3 +185,5 @@ inline fun <reified T1, reified T2, reified T3, R> functionInteractionInstance(
         }
     }
 }
+
+inline fun <reified T> javaTypeOf() = typeOf<T>().javaType

--- a/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
+++ b/core/baker-interface-kotlin/src/main/kotlin/com/ing/baker/runtime/kotlindsl/FunctionInteractionInstance.kt
@@ -10,10 +10,10 @@ import com.ing.baker.types.Converters
 import scala.collection.immutable.Map
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import kotlin.reflect.full.createType
 import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.reflect
+import kotlin.reflect.typeOf
 
 inline fun <reified T1, R> functionInteractionInstance(
     name: String,
@@ -21,7 +21,7 @@ inline fun <reified T1, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        T1::class.createType().javaType
+        typeOf<T1>().javaType
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")
@@ -76,8 +76,8 @@ inline fun <reified T1, reified T2, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        T1::class.createType().javaType,
-        T2::class.createType().javaType
+        typeOf<T1>().javaType,
+        typeOf<T2>().javaType
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")
@@ -133,9 +133,9 @@ inline fun <reified T1, reified T2, reified T3, R> functionInteractionInstance(
 ): InteractionInstance {
 
     val types = listOf(
-        T1::class.createType().javaType,
-        T2::class.createType().javaType,
-        T3::class.createType().javaType,
+        typeOf<T1>().javaType,
+        typeOf<T2>().javaType,
+        typeOf<T3>().javaType,
     )
 
     val params = function.reflect()?.parameters ?: error("Cannot read parameters")

--- a/core/baker-interface-kotlin/src/test/kotlin/FunctionInteractionInstanceTest.kt
+++ b/core/baker-interface-kotlin/src/test/kotlin/FunctionInteractionInstanceTest.kt
@@ -1,9 +1,17 @@
 import com.ing.baker.runtime.kotlindsl.functionInteractionInstance
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.*
 
 class FunctionInteractionInstanceTest {
 
+    @Test
+    fun `should handle function interaction with optional`() {
+        val func = { test: Optional<String> -> "" }
+        val interaction = functionInteractionInstance("test", func)
+
+        assertEquals(interaction.name(), "\$SieveInteraction\$test")
+    }
 
     @Test
     fun `should handle function interaction`() {

--- a/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -105,9 +105,9 @@ class RecipeBuilder(private val name: String) {
      */
     inline fun <reified T1,reified R> ingredient(name: String, noinline function: (T1) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(T1::class)
+        val ingredients = listOf(typeOf<T1>().javaType)
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
+            .map { (clazz, param) ->  Ingredient(param.name, clazz)}
         addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 
@@ -116,9 +116,9 @@ class RecipeBuilder(private val name: String) {
      */
     inline fun <reified T1, reified T2, reified R> ingredient(name: String, noinline function: (T1, T2) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(T1::class, T2::class)
+        val ingredients = listOf(typeOf<T1>().javaType, typeOf<T2>().javaType)
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
+            .map { (clazz, param) ->  Ingredient(param.name, clazz) }
         addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 
@@ -127,9 +127,9 @@ class RecipeBuilder(private val name: String) {
      */
     inline fun <reified T1, reified T2, reified T3, reified R> ingredient(name: String, noinline function: (T1, T2, T3) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(T1::class, T2::class, T3::class)
+        val ingredients = listOf(typeOf<T1>().javaType, typeOf<T2>().javaType, typeOf<T3>().javaType)
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz.createType().javaType) }
+            .map { (clazz, param) ->  Ingredient(param.name, clazz) }
         addSieve(name, ingredients, typeOf<R>().javaType, function)
     }
 

--- a/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -11,7 +11,6 @@ import java.lang.reflect.Type
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
-import kotlin.reflect.full.createType
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
@@ -103,12 +102,12 @@ class RecipeBuilder(private val name: String) {
     /**
      * Registers a sieve [T1, T2, R] to the recipe.
      */
-    inline fun <reified T1,reified R> ingredient(name: String, noinline function: (T1) -> R) {
+    inline fun <reified T1, reified R> ingredient(name: String, noinline function: (T1) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(typeOf<T1>().javaType)
+        val ingredients = listOf(javaTypeOf<T1>())
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz)}
-        addSieve(name, ingredients, typeOf<R>().javaType, function)
+            .map { (clazz, param) -> Ingredient(param.name, clazz) }
+        addSieve(name, ingredients, javaTypeOf<R>(), function)
     }
 
     /**
@@ -116,24 +115,27 @@ class RecipeBuilder(private val name: String) {
      */
     inline fun <reified T1, reified T2, reified R> ingredient(name: String, noinline function: (T1, T2) -> R) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(typeOf<T1>().javaType, typeOf<T2>().javaType)
+        val ingredients = listOf(javaTypeOf<T1>(), javaTypeOf<T2>())
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz) }
-        addSieve(name, ingredients, typeOf<R>().javaType, function)
+            .map { (clazz, param) -> Ingredient(param.name, clazz) }
+        addSieve(name, ingredients, javaTypeOf<R>(), function)
     }
 
     /**
      * Registers a sieve [T1, T2, R] to the recipe.
      */
-    inline fun <reified T1, reified T2, reified T3, reified R> ingredient(name: String, noinline function: (T1, T2, T3) -> R) {
+    inline fun <reified T1, reified T2, reified T3, reified R> ingredient(
+        name: String,
+        noinline function: (T1, T2, T3) -> R
+    ) {
         val parameters = function.reflect()?.parameters ?: error("Cannot read parameters")
-        val ingredients = listOf(typeOf<T1>().javaType, typeOf<T2>().javaType, typeOf<T3>().javaType)
+        val ingredients = listOf(javaTypeOf<T1>(), javaTypeOf<T2>(), javaTypeOf<T3>())
             .zip(parameters)
-            .map { (clazz, param) ->  Ingredient(param.name, clazz) }
-        addSieve(name, ingredients, typeOf<R>().javaType, function)
+            .map { (clazz, param) -> Ingredient(param.name, clazz) }
+        addSieve(name, ingredients, javaTypeOf<R>(), function)
     }
 
-    fun addSieve(name:String, ingredients:List<Ingredient>, returnType:Type, function:Any){
+    fun addSieve(name: String, ingredients: List<Ingredient>, returnType: Type, function: Any) {
         sieves.add(
             Sieve(
                 name,
@@ -570,3 +572,5 @@ private fun KClass<*>.toEvent(maxFiringLimit: Int? = null): Event {
 }
 
 private fun KFunction<*>.hasFiresEventAnnotation() = annotations.any { it.annotationClass == FiresEvent::class }
+
+inline fun <reified T> javaTypeOf() = typeOf<T>().javaType

--- a/core/recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
+++ b/core/recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
@@ -35,6 +35,9 @@ class KotlinDslTest {
                 until = deadline(20.0.seconds)
             }
 
+            // Ingredient definition failed with optionals
+            ingredient("test", { test: Optional<String> -> "" })
+
             sensoryEvents {
                 eventWithoutFiringLimit<Events.OrderPlaced>()
                 event<Events.PaymentInformationReceived>(maxFiringLimit = 5)


### PR DESCRIPTION
Bug surfaced when declaring recipe ingredients or functioninteractioninstances using the Kotlin DSL that contained optionals, but chances are all generic wrappers are affected. Patch to resolve this.