### PR TITLE
Refactor CI workflow to add conditional step for draft release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           cp .jvmopts-ci .jvmopts
           sbt coverage test coverageReport && bash <(curl -s https://codecov.io/bash)  
       - name: Prepare draft release notes
+        # Run this step only for pushes to the master branch or for tags starting with 'v'
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
         continue-on-error: true
         uses: release-drafter/release-drafter@v6
         with:


### PR DESCRIPTION
This pull request refactors the CI workflow to add a conditional step for generating draft release notes. The step will only run for pushes to the master branch or for tags starting with 'v'. This ensures that draft release notes are only prepared when necessary, reducing unnecessary processing and improving efficiency.