### PR TITLE
Bugfix: add metadata together with process initilization

### DIFF
--- a/core/akka-runtime/src/main/protobuf/process_index.proto
+++ b/core/akka-runtime/src/main/protobuf/process_index.proto
@@ -62,6 +62,7 @@ message Index {
 message CreateProcess {
     optional string recipeId = 1;
     optional string recipeInstanceId = 2;
+    repeated AddRecipeInstanceMetaDataRecord metaData = 3;
 }
 
 message ProcessEvent {

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
@@ -214,16 +214,7 @@ class AkkaBaker private[runtime](config: AkkaBakerConfig) extends scaladsl.Baker
     * @return
     */
   override def bake(recipeId: String, recipeInstanceId: String): Future[Unit] = {
-    processIndexActor.ask(CreateProcess(recipeId, recipeInstanceId))(config.timeouts.defaultBakeTimeout).javaTimeoutToBakerTimeout("bake").flatMap {
-      case _: Initialized =>
-        Future.successful(())
-      case ProcessDeleted =>
-        Future.failed(ProcessDeletedException(recipeInstanceId))
-      case ProcessAlreadyExists(_) =>
-        Future.failed(ProcessAlreadyExistsException(recipeInstanceId))
-      case RecipeManagerProtocol.NoRecipeFound(_) =>
-        Future.failed(NoSuchRecipeException(recipeId))
-    }
+    bake(recipeId, recipeInstanceId, Map.empty)
   }
 
   /**
@@ -237,7 +228,16 @@ class AkkaBaker private[runtime](config: AkkaBakerConfig) extends scaladsl.Baker
     * @return
     */
   override def bake(recipeId: String, recipeInstanceId: String, metadata: Map[String, String]): Future[Unit] = {
-    bake(recipeId, recipeInstanceId).map(_ -> addMetaData(recipeInstanceId, metadata))
+    processIndexActor.ask(CreateProcess(recipeId, recipeInstanceId, metadata))(config.timeouts.defaultBakeTimeout).javaTimeoutToBakerTimeout("bake").flatMap {
+      case _: Initialized =>
+        Future.successful(())
+      case ProcessDeleted =>
+        Future.failed(ProcessDeletedException(recipeInstanceId))
+      case ProcessAlreadyExists(_) =>
+        Future.failed(ProcessAlreadyExistsException(recipeInstanceId))
+      case RecipeManagerProtocol.NoRecipeFound(_) =>
+        Future.failed(NoSuchRecipeException(recipeId))
+    }
   }
 
   override def fireEventAndResolveWhenReceived(recipeInstanceId: String, event: EventInstance, correlationId: Option[String]): Future[SensoryEventStatus] =

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProtocol.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndexProtocol.scala
@@ -61,8 +61,9 @@ object ProcessIndexProtocol {
     *
     * @param recipeId Id of the recipe to use, must exist on the Recipe Manager
     * @param recipeInstanceId To be used for the process, must not be previously used
+    * @param metaData Additional metadata to be stored with the process
     */
-  case class CreateProcess(recipeId: String, recipeInstanceId: String) extends ProcessIndexMessage
+  case class CreateProcess(recipeId: String, recipeInstanceId: String, metaData: Map[String, String] = Map.empty) extends ProcessIndexMessage
 
   /**
     * Returned if there was already another process using the predefined process id

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
@@ -83,7 +83,7 @@ object ProcessInstanceProtocol {
   sealed trait Response extends BakerSerializable
 
   /**
-   * A response send in case any other command then 'Initialize' is sent to the actor in unitialized state.
+   * A response send in case any other command then 'Initialize' is sent to the actor in initialized state.
    *
    * @param recipeInstanceId The identifier of the uninitialized actor.
    */

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/internal/Instance.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/internal/Instance.scala
@@ -6,7 +6,16 @@ import com.ing.baker.petrinet.api._
 import scala.util.Random
 
 object Instance {
-  def uninitialized[S](process: PetriNet): Instance[S] = Instance[S](process, 0, Marking.empty, Map.empty, null.asInstanceOf[S], Map.empty, Set.empty)
+  def uninitialized[S](process: PetriNet): Instance[S] =
+    Instance[S](
+      petriNet = process,
+      sequenceNr = 0,
+      marking = Marking.empty,
+      delayedTransitionIds = Map.empty,
+      state = null.asInstanceOf[S],
+      jobs = Map.empty,
+      receivedCorrelationIds = Set.empty
+    )
 }
 
 /**

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/InteractionExecution.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/InteractionExecution.scala
@@ -49,7 +49,7 @@ object InteractionExecution {
   }
   case class Failure(reason: FailureReason) extends Result {
     def toBakerInteractionExecutionFailure: InteractionExecutionResult.Failure = reason match {
-      case InteractionError(interactionName, message) => InteractionExecutionResult.Failure(InteractionExecutionFailureReason.INTERACTION_NOT_FOUND, Some(interactionName), Some(message))
+      case InteractionError(interactionName, message) => InteractionExecutionResult.Failure(InteractionExecutionFailureReason.INTERACTION_EXECUTION_ERROR, Some(interactionName), Some(message))
       case NoInstanceFound => InteractionExecutionResult.Failure(InteractionExecutionFailureReason.INTERACTION_NOT_FOUND, None, None)
       case Timeout => InteractionExecutionResult.Failure(InteractionExecutionFailureReason.TIMEOUT, None, None)
       case BadIngredients => InteractionExecutionResult.Failure(InteractionExecutionFailureReason.BAD_INGREDIENTS, None, None)


### PR DESCRIPTION
This pull request includes several changes to enhance metadata handling and improve code readability in the `akka-runtime` module. The most important changes include adding metadata support to the `CreateProcess` message and refactoring the `bake` method.
These changes collectively improve the handling of process metadata during initialize phase and enhance the readability and maintainability of the codebase.