### PR TITLE
Update Azure publish conditions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
       contents: write
       pull-requests: write
     name: Publish to Azure
-    # Publish to Azure for all pull requests and all the commits for all the branches from the original repo except for tags.
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && ! startsWith(github.ref, 'refs/tags/') && ! github.event.repository.fork }}
+    # Publish to Azure only for push events and pull requests from the main repo except for tags
+    if: ${{ (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) && ! startsWith(github.ref, 'refs/tags/') }}
     needs: [ci]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Restrict Azure publishing to push events and pull requests originating from the main repository, excluding tags. This ensures workflows do not run for pull requests from forked repositories.