### PR TITLE
WIP: FireEventAfterFailure retry strategy

### DIFF
--- a/bakery/state/src/main/scala/com/ing/bakery/components/EventSink.scala
+++ b/bakery/state/src/main/scala/com/ing/bakery/components/EventSink.scala
@@ -60,6 +60,8 @@ class KafkaEventSink(config: Config) extends EventSink with LazyLogging {
       EventRecord("RecipeInstanceCreated", Option(recipeInstanceId), recipeId)
     case RecipeAdded(recipeName, _, _, _) =>
       EventRecord("RecipeAdded", None, recipeName)
+    case EventFired(_, _, _, recipeInstanceId, eventName) =>
+      EventRecord("EventFired", Some(recipeInstanceId), eventName)
   }
 
   private def producerCallback(promise: Promise[RecordMetadata]): Callback =

--- a/core/akka-runtime/src/main/protobuf/process_instance.proto
+++ b/core/akka-runtime/src/main/protobuf/process_instance.proto
@@ -62,6 +62,20 @@ message TransitionFailedWithOutput {
     optional SerializedData data = 8;
 }
 
+message TransitionFailedWithFunctionalOutput {
+  option (scalapb.message).extends = "com.ing.baker.runtime.akka.actor.serialization.BakerSerializable";
+
+  optional int64 job_id = 1;
+  optional string correlation_id = 9;
+  optional int64 transition_id = 3;
+  optional int64 time_started = 4;
+  optional int64 time_completed = 5;
+  repeated ConsumedToken consumed = 6;
+  repeated ProducedToken produced = 7;
+  optional SerializedData data = 8;
+}
+
+
 message TransitionDelayed {
     option (scalapb.message).extends = "com.ing.baker.runtime.akka.actor.serialization.BakerSerializable";
     optional int64 job_id = 1;
@@ -209,6 +223,7 @@ message FailureStrategyMessage {
 //        FATAL = 1; deprecated option, do not re-use this identifier!
         RETRY = 2;
         CONTINUE = 3;
+        CONTINUE_FUNCTIONAL = 4;
     }
 
     optional StrategyTypeMessage strategyType = 1;

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/AkkaBaker.scala
@@ -516,6 +516,8 @@ class AkkaBaker private[runtime](config: AkkaBakerConfig) extends scaladsl.Baker
         listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), event)
       case InteractionFailed(_, _, recipeName, recipeId, recipeInstanceId, _, _, _, ExceptionStrategyOutcome.Continue(eventName)) if processFilter(recipeName) =>
         listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), eventName)
+      case InteractionFailed(_, _, recipeName, recipeId, recipeInstanceId, _, _, _, ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName)) if processFilter(recipeName) =>
+        listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), eventName)
       case _ => ()
     }
   }

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/delayed_transition_actor/DelayedTransitionActor.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/delayed_transition_actor/DelayedTransitionActor.scala
@@ -118,7 +118,7 @@ class DelayedTransitionActor(processIndex: ActorRef,
           persistWithSnapshot(DelayedTransitionExecuted(id, instance)) { _ =>
             waitingTransitions -= id
           }
-        case None => log.error(s"FireDelayedTransitionAck received for $id but not found")
+        case None => log.warning(s"FireDelayedTransitionAck received for $id but not found")
       }
 
     case ProcessDeleted(recipeInstanceId) =>

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
@@ -530,7 +530,7 @@ class ProcessIndex(recipeInstanceIdleTimeout: Option[FiniteDuration],
       context.stop(sender())
 
     case StopProcessIndexShard =>
-      log.debug("StopProcessIndexShard received, stopping self")
+      log.info("StopProcessIndexShard received, stopping self")
       context.stop(delayedTransitionActor)
       context.stop(self)
 
@@ -668,10 +668,14 @@ class ProcessIndex(recipeInstanceIdleTimeout: Option[FiniteDuration],
           deleteProcess(process._2)
         }
       )
+
       // Start the active processes
       index
-        .filter(process => process._2.processStatus == Active ).keys
-        .foreach(id => createProcessActor(id))
+        .filter(process => process._2.processStatus == Active).keys
+        .foreach(id => {
+          log.debug(s"Starting child actor after recovery: $id")
+          createProcessActor(id)
+        })
       delayedTransitionActor ! StartTimer
   }
 

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_index/ProcessIndex.scala
@@ -664,7 +664,7 @@ class ProcessIndex(recipeInstanceIdleTimeout: Option[FiniteDuration],
       index.foreach(process =>
         if(blacklistedProcesses.contains(process._1) && !process._2.isDeleted) {
           val id = process._1
-          log.debug(s"Deleting blacklistedProcesses $id")
+          log.info(s"Deleting blacklistedProcesses $id")
           deleteProcess(process._2)
         }
       )

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstance.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstance.scala
@@ -399,12 +399,9 @@ class ProcessInstance[S, E](
             }
         )
       } else {
-        log.warning("Ignoring DelayedTransitionFired since there is no open asyncConsumedMarkings")
+        log.error(s"Ignoring DelayedTransitionFired since there is no open asyncConsumedMarkings for transition: $transitionId with count: ${instance.delayedTransitionIds.get(transitionId)}")
         //The DelayedTransition is acknowledged so that it is removed from the DelayedTransitionManager.
         delayedTransitionActor ! FireDelayedTransitionAck(recipeInstanceId, jobId)
-        instance.copy[S](
-          sequenceNr = instance.sequenceNr + 1
-        )
       }
 
     case event@TransitionFailedEvent(jobId, transitionId, correlationId, timeStarted, timeFailed, consume, input, reason, strategy) =>

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProto.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProto.scala
@@ -51,6 +51,7 @@ object ProcessInstanceProto {
         a match {
           case ExceptionStrategy.BlockTransition => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.BLOCK_TRANSITION), None)
           case ExceptionStrategy.Continue(marking, output) => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.CONTINUE), None, toProtoMarking(marking), Some(ctxToProto(output.asInstanceOf[AnyRef])))
+          case ExceptionStrategy.ContinueAsFunctional(marking, output) => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.CONTINUE_FUNCTIONAL), None, toProtoMarking(marking), Some(ctxToProto(output.asInstanceOf[AnyRef])))
           case ExceptionStrategy.RetryWithDelay(delay) => protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.RETRY), Some(delay))
         }
 
@@ -65,6 +66,11 @@ object ProcessInstanceProto {
               marking <- toDomainMarking(markingProto)
               output <- ctxFromProto(outputProto)
             } yield ExceptionStrategy.Continue(marking, output)
+          case protobuf.FailureStrategyMessage(Some(StrategyTypeMessage.CONTINUE_FUNCTIONAL), _, markingProto, Some(outputProto)) =>
+            for {
+              marking <- toDomainMarking(markingProto)
+              output <- ctxFromProto(outputProto)
+            } yield ExceptionStrategy.ContinueAsFunctional(marking, output)
           case _ =>
             Failure(new IllegalStateException("Got a protobuf.FailureStrategyMessage with an unrecognized StrategyTypeMessage"))
         }

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/ProcessInstanceProtocol.scala
@@ -208,6 +208,15 @@ object ProcessInstanceProtocol {
 
       def isContinue: Boolean = true
     }
+
+    case class ContinueAsFunctional(marking: Marking[Id], output: Any) extends ExceptionStrategy {
+
+      def isBlock: Boolean = false
+
+      def isRetry: Boolean = false
+
+      def isContinue: Boolean = true
+    }
   }
 
   /**

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/internal/ExceptionStrategy.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/process_instance/internal/ExceptionStrategy.scala
@@ -17,6 +17,8 @@ object ExceptionStrategy {
   }
 
   case class Continue[X, O](marking: Marking[X], output: O) extends ExceptionStrategy
+
+  case class ContinueAsFunctionalEvent[X, O](marking: Marking[X], output: O) extends ExceptionStrategy
 }
 
 sealed trait ExceptionStrategy

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/BakerTypedProtobufSerializer.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/actor/serialization/BakerTypedProtobufSerializer.scala
@@ -149,6 +149,8 @@ object BakerTypedProtobufSerializer {
         .register("TransitionFired")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFired)),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailedWithOutput]
         .register("TransitionFailedWithOutput")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailedWithOutput)),
+      forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailedWithFunctionalOutput]
+        .register("TransitionFailedWithFunctionalOutput")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailedWithFunctionalOutput)),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailed]
         .register("TransitionFailed")(ProtoMap.identityProtoMap(com.ing.baker.runtime.akka.actor.process_instance.protobuf.TransitionFailed)),
       forType[com.ing.baker.runtime.akka.actor.process_instance.protobuf.Initialized]

--- a/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
+++ b/core/akka-runtime/src/main/scala/com/ing/baker/runtime/akka/internal/RecipeRuntime.scala
@@ -10,7 +10,7 @@ import com.ing.baker.il.{CompiledRecipe, IngredientDescriptor}
 import com.ing.baker.petrinet.api.{MultiSet, _}
 import com.ing.baker.runtime.akka.actor.logging.LogAndSendEvent
 import com.ing.baker.runtime.akka.actor.process_instance.ProcessInstanceRuntime
-import com.ing.baker.runtime.akka.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, Continue, RetryWithDelay}
+import com.ing.baker.runtime.akka.actor.process_instance.internal.ExceptionStrategy.{BlockTransition, Continue, ContinueAsFunctionalEvent, RetryWithDelay}
 import com.ing.baker.runtime.akka.actor.process_instance.internal._
 import com.ing.baker.runtime.akka.internal.RecipeRuntime._
 import com.ing.baker.runtime.model.InteractionManager
@@ -183,6 +183,9 @@ class RecipeRuntime(recipe: CompiledRecipe, interactionManager: InteractionManag
             case ExceptionStrategyOutcome.Continue(eventName) =>
               val runtimeEvent = EventInstance(eventName, Map.empty)
               Continue(createProducedMarking(outMarking, Some(runtimeEvent)), runtimeEvent)
+            case ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName) =>
+              val runtimeEvent = EventInstance(eventName, Map.empty)
+              ContinueAsFunctionalEvent(createProducedMarking(outMarking, Some(runtimeEvent)), runtimeEvent)
           }
 
         case _ => BlockTransition

--- a/core/akka-runtime/src/test/scala/com/ing/baker/AllTypeRecipe.scala
+++ b/core/akka-runtime/src/test/scala/com/ing/baker/AllTypeRecipe.scala
@@ -181,7 +181,7 @@ object AllTypeRecipe {
         ),
         interactionFive
           .withRequiredEvent(byteArrayEvent)
-          .withFailureStrategy(InteractionFailureStrategy.FireEventAfterFailure()),
+          .withFailureStrategy(InteractionFailureStrategy.FireEventAndBlock()),
         interactionSix,
         interactionSeven,
         sieveInteraction,

--- a/core/akka-runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
+++ b/core/akka-runtime/src/test/scala/com/ing/baker/BakerRuntimeTestBase.scala
@@ -2,7 +2,7 @@ package com.ing.baker
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import com.ing.baker.compiler.RecipeCompiler
 import com.ing.baker.il.CompiledRecipe
 import com.ing.baker.recipe.CaseClassIngredient
@@ -39,7 +39,7 @@ trait BakerRuntimeTestBase
   def actorSystemName: String
 
   implicit val timeout: FiniteDuration = 10 seconds
-  implicit val contextShift = IO.contextShift(ExecutionContext.global)
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   //Values to use for setting and checking the ingredients
 
   //Default values to be used for the ingredients in the tests

--- a/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/SensoryEventResponseHandlerSpec.scala
+++ b/core/akka-runtime/src/test/scala/com/ing/baker/runtime/akka/actor/process_index/SensoryEventResponseHandlerSpec.scala
@@ -20,7 +20,7 @@ class SensoryEventResponseHandlerSpec extends AkkaTestBase("SensoryEventResponse
   implicit val ec: ExecutionContext = system.dispatcher
 
   // Using dilated timeout to take into account the akka.test.timefactor config
-  implicit val timeout = 2.seconds.dilated
+  implicit val timeout: FiniteDuration = 2.seconds.dilated
 
   "The ProcessApi" should {
 

--- a/core/baker-interface/src/main/protobuf/common.proto
+++ b/core/baker-interface/src/main/protobuf/common.proto
@@ -264,12 +264,16 @@ message BlockInteraction {}
 message FireEventAfterFailure {
     optional EventDescriptor event = 1;
 }
+message FireFunctionalEventAfterFailure {
+  optional EventDescriptor event = 1;
+}
 message RetryWithIncrementalBackoff {
     optional int64 initialTimeout = 1;
     optional double backoffFactor = 2;
     optional int32 maximumRetries = 3;
     optional int64 maxTimeBetweenRetries = 4;
     optional EventDescriptor retryExhaustedEvent = 5;
+    optional EventDescriptor retryFunctionalEvent = 6;
 }
 
 message InteractionFailureStrategy {
@@ -277,6 +281,7 @@ message InteractionFailureStrategy {
         BlockInteraction blockInteraction = 1;
         FireEventAfterFailure fireEventAfterFailure = 2;
         RetryWithIncrementalBackoff retryWithIncrementalBackoff = 3;
+        FireFunctionalEventAfterFailure fireFunctionalEventAfterFailure = 4;
     }
 }
 
@@ -334,6 +339,7 @@ enum RejectReason {
 message ExceptionStrategyOutcome {
     optional string eventName = 1;
     optional int64 delay = 2;
+    optional string functionalEventName = 3;
 }
 
 message EventReceivedBakerEvent {

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/BakerF.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/BakerF.scala
@@ -365,6 +365,8 @@ abstract class BakerF[F[_]](implicit components: BakerComponents[F], effect: Con
         listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), event)
       case InteractionFailed(_, _, recipeName, recipeId, recipeInstanceId, _, _, _, ExceptionStrategyOutcome.Continue(eventName)) if processFilter(recipeName) =>
         listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), eventName)
+      case InteractionFailed(_, _, recipeName, recipeId, recipeInstanceId, _, _, _, ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName)) if processFilter(recipeName) =>
+        listenerFunction.apply(RecipeEventMetadata(recipeId = recipeId, recipeName = recipeName, recipeInstanceId = recipeInstanceId), eventName)
       case _ => ()
     }
 

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstance.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstance.scala
@@ -108,7 +108,14 @@ case class RecipeInstance[F[_]](recipeInstanceId: String, config: RecipeInstance
       case Left(ExceptionStrategyOutcome.Continue(eventName)) =>
         val output: EventInstance = EventInstance(eventName, Map.empty)
         for {
-          enabledExecutions <- state.modify(_.recordFailedWithOutputExecution(finishedExecution, Some(output)))
+          enabledExecutions <- state.modify(_.recordFailedWithOutputExecution(finishedExecution, output))
+          _ <- scheduleIdleStop
+        } yield Some(output) -> enabledExecutions
+
+      case Left(ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName)) =>
+        val output: EventInstance = EventInstance(eventName, Map.empty)
+        for {
+          enabledExecutions <- state.modify(_.recordFailedWithOutputExecutionAsFunctionalEvent(finishedExecution, output))
           _ <- scheduleIdleStop
         } yield Some(output) -> enabledExecutions
 

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstanceState.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/model/recipeinstance/RecipeInstanceState.scala
@@ -73,12 +73,20 @@ case class RecipeInstanceState(
   def recordFailedExecution(transitionExecution: TransitionExecution, exceptionStrategy: ExceptionStrategyOutcome): RecipeInstanceState =
     addExecution(transitionExecution.toFailedState(exceptionStrategy))
 
-  def recordFailedWithOutputExecution(transitionExecution: TransitionExecution, output: Option[EventInstance]): (RecipeInstanceState, Set[TransitionExecution]) =
-    aggregateOutputEvent(output)
+  def recordFailedWithOutputExecution(transitionExecution: TransitionExecution, output: EventInstance): (RecipeInstanceState, Set[TransitionExecution]) =
+    aggregateOutputEvent(Some(output))
       .increaseSequenceNumber
-      .aggregatePetriNetChanges(transitionExecution, output)
+      .aggregatePetriNetChanges(transitionExecution, Some(output))
       .addCompletedCorrelationId(transitionExecution)
       .addExecution(transitionExecution.copy(state = TransitionExecution.State.Failed(transitionExecution.failureCount, ExceptionStrategyOutcome.BlockTransition)))
+      .allEnabledExecutions
+
+  def recordFailedWithOutputExecutionAsFunctionalEvent(transitionExecution: TransitionExecution, output: EventInstance): (RecipeInstanceState, Set[TransitionExecution]) =
+    aggregateOutputEvent(Some(output))
+      .increaseSequenceNumber
+      .aggregatePetriNetChanges(transitionExecution, Some(output))
+      .addCompletedCorrelationId(transitionExecution)
+      .removeExecution(transitionExecution)
       .allEnabledExecutions
 
   def recordCompletedExecution(transitionExecution: TransitionExecution, output: Option[EventInstance]): (RecipeInstanceState, Set[TransitionExecution]) =

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/BakerEventMapping.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/BakerEventMapping.scala
@@ -164,9 +164,10 @@ object BakerEventMapping {
         interactionName = Some(a.interactionName),
         failureCount = Some(a.failureCount),
         exceptionStrategyOutcome = Some(a.exceptionStrategyOutcome match {
-          case ExceptionStrategyOutcome.BlockTransition => protobuf.ExceptionStrategyOutcome(eventName = None, delay = None)
-          case ExceptionStrategyOutcome.Continue(eventName) => protobuf.ExceptionStrategyOutcome(eventName = Some(eventName), delay = None)
-          case ExceptionStrategyOutcome.RetryWithDelay(delay) => protobuf.ExceptionStrategyOutcome(eventName = None, delay = Some(delay))
+          case ExceptionStrategyOutcome.BlockTransition => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = None, delay = None)
+          case ExceptionStrategyOutcome.Continue(eventName) => protobuf.ExceptionStrategyOutcome(eventName = Some(eventName), functionalEventName = None, delay = None)
+          case ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName) => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = Some(eventName), delay = None)
+          case ExceptionStrategyOutcome.RetryWithDelay(delay) => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = None, delay = Some(delay))
         })
       )
 
@@ -191,8 +192,9 @@ object BakerEventMapping {
         failureCount = failureCount,
         errorMessage = errorMessage,
         exceptionStrategyOutcome = exceptionStrategyOutcome match {
-          case protobuf.ExceptionStrategyOutcome(Some(eventName), None) => ExceptionStrategyOutcome.Continue(eventName)
-          case protobuf.ExceptionStrategyOutcome(None, Some(delay)) => ExceptionStrategyOutcome.RetryWithDelay(delay)
+          case protobuf.ExceptionStrategyOutcome(Some(eventName), None, None) => ExceptionStrategyOutcome.Continue(eventName)
+          case protobuf.ExceptionStrategyOutcome(None, None, Some(functionalEventName)) => ExceptionStrategyOutcome.ContinueAsFunctionalEvent(functionalEventName)
+          case protobuf.ExceptionStrategyOutcome(None, Some(delay), None) => ExceptionStrategyOutcome.RetryWithDelay(delay)
           case _ => ExceptionStrategyOutcome.BlockTransition
         }
       )

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/BakerEventMapping.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/serialization/protomappings/BakerEventMapping.scala
@@ -164,10 +164,14 @@ object BakerEventMapping {
         interactionName = Some(a.interactionName),
         failureCount = Some(a.failureCount),
         exceptionStrategyOutcome = Some(a.exceptionStrategyOutcome match {
-          case ExceptionStrategyOutcome.BlockTransition => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = None, delay = None)
-          case ExceptionStrategyOutcome.Continue(eventName) => protobuf.ExceptionStrategyOutcome(eventName = Some(eventName), functionalEventName = None, delay = None)
-          case ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName) => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = Some(eventName), delay = None)
-          case ExceptionStrategyOutcome.RetryWithDelay(delay) => protobuf.ExceptionStrategyOutcome(eventName = None, functionalEventName = None, delay = Some(delay))
+          case ExceptionStrategyOutcome.BlockTransition =>
+            protobuf.ExceptionStrategyOutcome(eventName = None, delay = None, functionalEventName = None)
+          case ExceptionStrategyOutcome.Continue(eventName) =>
+            protobuf.ExceptionStrategyOutcome(eventName = Some(eventName), delay = None, functionalEventName = None)
+          case ExceptionStrategyOutcome.ContinueAsFunctionalEvent(eventName) =>
+            protobuf.ExceptionStrategyOutcome(eventName = None, delay = None, functionalEventName = Some(eventName))
+          case ExceptionStrategyOutcome.RetryWithDelay(delay) =>
+            protobuf.ExceptionStrategyOutcome(eventName = None, delay = Some(delay), functionalEventName = None)
         })
       )
 
@@ -192,10 +196,14 @@ object BakerEventMapping {
         failureCount = failureCount,
         errorMessage = errorMessage,
         exceptionStrategyOutcome = exceptionStrategyOutcome match {
-          case protobuf.ExceptionStrategyOutcome(Some(eventName), None, None) => ExceptionStrategyOutcome.Continue(eventName)
-          case protobuf.ExceptionStrategyOutcome(None, None, Some(functionalEventName)) => ExceptionStrategyOutcome.ContinueAsFunctionalEvent(functionalEventName)
-          case protobuf.ExceptionStrategyOutcome(None, Some(delay), None) => ExceptionStrategyOutcome.RetryWithDelay(delay)
-          case _ => ExceptionStrategyOutcome.BlockTransition
+          case protobuf.ExceptionStrategyOutcome(Some(eventName), None, None) =>
+            ExceptionStrategyOutcome.Continue(eventName)
+          case protobuf.ExceptionStrategyOutcome(None, None, Some(functionalEventName)) =>
+            ExceptionStrategyOutcome.ContinueAsFunctionalEvent(functionalEventName)
+          case protobuf.ExceptionStrategyOutcome(None, Some(delay), None) =>
+            ExceptionStrategyOutcome.RetryWithDelay(delay)
+          case _ =>
+            ExceptionStrategyOutcome.BlockTransition
         }
       )
   }

--- a/core/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/JsonDecodersSpec.scala
+++ b/core/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/JsonDecodersSpec.scala
@@ -1,5 +1,6 @@
 package com.ing.baker.runtime.serialization
 
+import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome
 import com.ing.baker.runtime.scaladsl.{EventInstance, InteractionInstanceDescriptor, InteractionInstanceInput}
 import com.ing.baker.runtime.serialization.JsonDecoders._
 import com.ing.baker.types._
@@ -8,7 +9,6 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import scala.collection.immutable.Seq
 
 @nowarn
 class JsonDecodersSpec extends AnyFunSpec with Matchers {
@@ -104,6 +104,20 @@ class JsonDecodersSpec extends AnyFunSpec with Matchers {
 
       val addMetaDataRequestWithData = decode[AddMetaDataRequest]("""{"metadata":{"Key1":"Value1"}}""").right.get
       addMetaDataRequestWithData shouldEqual AddMetaDataRequest(Map("Key1"-> "Value1"))
+    }
+
+    it("should decode ExceptionStrategyOutcome") {
+      val blockTransition = decode[ExceptionStrategyOutcome]("""{"BlockTransition":{}}""").right.get
+      blockTransition shouldEqual ExceptionStrategyOutcome.BlockTransition
+
+      val retryException = decode[ExceptionStrategyOutcome]("""{"RetryWithDelay":{"delay":10}}""").right.get
+      retryException shouldEqual ExceptionStrategyOutcome.RetryWithDelay(10)
+
+      val continueException = decode[ExceptionStrategyOutcome]("""{"Continue":{"eventName":"event name"}}""").right.get
+      continueException shouldEqual  ExceptionStrategyOutcome.Continue("event name")
+
+      val continueAsFunctionalEvent = decode[ExceptionStrategyOutcome]("""{"ContinueAsFunctionalEvent":{"eventName":"event name"}}""").right.get
+      continueAsFunctionalEvent shouldEqual ExceptionStrategyOutcome.ContinueAsFunctionalEvent("event name")
     }
   }
 }

--- a/core/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/JsonEncodersSpec.scala
+++ b/core/baker-interface/src/test/scala/com/ing/baker/runtime/serialization/JsonEncodersSpec.scala
@@ -50,6 +50,9 @@ class JsonEncodersSpec extends AnyFunSpec with Matchers {
 
       val continueException: ExceptionStrategyOutcome = ExceptionStrategyOutcome.Continue("event name")
       continueException.asJson.noSpaces shouldEqual """{"Continue":{"eventName":"event name"}}"""
+
+      val continueAsFunctionalEvent: ExceptionStrategyOutcome = ExceptionStrategyOutcome.ContinueAsFunctionalEvent("event name")
+      continueAsFunctionalEvent.asJson.noSpaces shouldEqual  """{"ContinueAsFunctionalEvent":{"eventName":"event name"}}"""
     }
 
     it("should encode Throwable") {

--- a/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/ExceptionStrategyOutcome.scala
+++ b/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/ExceptionStrategyOutcome.scala
@@ -14,7 +14,19 @@ object ExceptionStrategyOutcome {
     require(delay >= 0, "Delay must be greater or equal then zero")
   }
 
+  /**
+   * Fires this event after a technical failure occurs and blocks the interaction from execution.
+   * The interaction can only be continued using the retryInteraction method on Baker.
+   * @param eventName
+   */
   case class Continue(eventName: String) extends ExceptionStrategyOutcome
+
+  /**
+   * Fires this event after a technical failure occurs and does not block the interaction.
+   * The interaction cannot be retried using the retryInteraction but can be started again if preconditions are met again.
+   * @param eventName
+   */
+  case class ContinueAsFunctionalEvent(eventName: String) extends ExceptionStrategyOutcome
 }
 
 sealed trait ExceptionStrategyOutcome

--- a/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/FireFunctionalEventAfterFailure.scala
+++ b/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/FireFunctionalEventAfterFailure.scala
@@ -1,0 +1,9 @@
+package com.ing.baker.il.failurestrategy
+
+import com.ing.baker.il.EventDescriptor
+import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome.ContinueAsFunctionalEvent
+
+case class FireFunctionalEventAfterFailure(event: EventDescriptor) extends InteractionFailureStrategy {
+
+  override def apply(n: Int): ExceptionStrategyOutcome = ContinueAsFunctionalEvent(event.name)
+}

--- a/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoff.scala
+++ b/core/intermediate-language/src/main/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoff.scala
@@ -1,7 +1,7 @@
 package com.ing.baker.il.failurestrategy
 
 import com.ing.baker.il.EventDescriptor
-import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome.{BlockTransition, Continue, RetryWithDelay}
+import com.ing.baker.il.failurestrategy.ExceptionStrategyOutcome.{BlockTransition, Continue, ContinueAsFunctionalEvent, RetryWithDelay}
 import com.ing.baker.il.failurestrategy.RetryWithIncrementalBackoff._
 
 import java.util.concurrent.TimeUnit
@@ -34,7 +34,7 @@ case class RetryWithIncrementalBackoff(initialTimeout: Duration,
   def apply(n: Int): ExceptionStrategyOutcome = {
     if (n <= maximumRetries) RetryWithDelay(determineTimeToNextRetry(n))
     else if (retryExhaustedEvent.isDefined) Continue(retryExhaustedEvent.get.name)
-//    else if (retryWithFunctionalEvent.isDefined) ContinueAsFunctionalEvent(retryWithFunctionalEvent.get.name)
+    else if (retryWithFunctionalEvent.isDefined) ContinueAsFunctionalEvent(retryWithFunctionalEvent.get.name)
     else BlockTransition
   }
 

--- a/core/intermediate-language/src/main/scala/com/ing/baker/il/package.scala
+++ b/core/intermediate-language/src/main/scala/com/ing/baker/il/package.scala
@@ -14,6 +14,7 @@ package object il {
   val recipeInstanceEventListName = "RecipeInstanceEventList"
   val processIdName = "$ProcessID$" //needed for backwards compatibility with V1 and V2
   val exhaustedEventAppend = "RetryExhausted"
+  val functionalFailedEventAppend = "FunctionalFailed"
 
   val checkpointEventInteractionPrefix = "$CheckpointEventInteraction$"
   val subRecipePrefix = "$SubRecipe$"

--- a/core/intermediate-language/src/test/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoffSpec.scala
+++ b/core/intermediate-language/src/test/scala/com/ing/baker/il/failurestrategy/RetryWithIncrementalBackoffSpec.scala
@@ -10,7 +10,7 @@ class RetryWithIncrementalBackoffSpec extends AnyWordSpecLike with Matchers {
 
   "The RetryWithIncrementalBackoff" should {
     "return RetryWithDelay with the correct time until the next retry" in {
-      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 5, None, None)
+      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 5, None, None, None)
       retry(1) shouldBe RetryWithDelay(1)
       retry(2) shouldBe RetryWithDelay(2)
       retry(3) shouldBe RetryWithDelay(4)
@@ -19,19 +19,19 @@ class RetryWithIncrementalBackoffSpec extends AnyWordSpecLike with Matchers {
     }
 
     "return BlockTransition when retry max times fired is met" in {
-      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 5, None, None)
+      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 5, None, None, None)
       retry(6) shouldBe BlockTransition
     }
 
     "return the max retry time when retry max time is met" in {
-      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 10, Some(Duration(10, MILLISECONDS)), None)
+      val retry = RetryWithIncrementalBackoff(Duration(1, MILLISECONDS), 2.0, 10, Some(Duration(10, MILLISECONDS)), None, None)
       retry(4) shouldBe RetryWithDelay(8)
       retry(5) shouldBe RetryWithDelay(10)
       retry(6) shouldBe RetryWithDelay(10)
     }
 
     "Not fail if retry gets to big" in {
-      val retry = RetryWithIncrementalBackoff(Duration(10, MILLISECONDS), 2.0, 100, Some(Duration(10, MILLISECONDS)), None)
+      val retry = RetryWithIncrementalBackoff(Duration(10, MILLISECONDS), 2.0, 100, Some(Duration(10, MILLISECONDS)), None, None)
       retry(42) shouldBe RetryWithDelay(10)
       retry(101) shouldBe BlockTransition
     }

--- a/core/recipe-compiler/src/main/scala/com/ing/baker/compiler/package.scala
+++ b/core/recipe-compiler/src/main/scala/com/ing/baker/compiler/package.scala
@@ -98,7 +98,12 @@ package object compiler {
             val exhaustedRetryEvent: EventDescriptor = EventDescriptor(eventName, Seq.empty)
             (il.failurestrategy.FireEventAfterFailure(exhaustedRetryEvent), Some(exhaustedRetryEvent), None)
 
-          case common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(eventNameOption) =>
+          case common.InteractionFailureStrategy.FireEventAndBlock(eventNameOption) =>
+            val eventName = eventNameOption.getOrElse(interactionDescriptor.name + exhaustedEventAppend)
+            val exhaustedRetryEvent: EventDescriptor = EventDescriptor(eventName, Seq.empty)
+            (il.failurestrategy.FireEventAfterFailure(exhaustedRetryEvent), Some(exhaustedRetryEvent), None)
+
+          case common.InteractionFailureStrategy.FireEventAndResolve(eventNameOption) =>
             val eventName = eventNameOption.getOrElse(interactionDescriptor.name + functionalFailedEventAppend)
             val functionalFailed: EventDescriptor = EventDescriptor(eventName, Seq.empty)
             (il.failurestrategy.FireFunctionalEventAfterFailure(functionalFailed), None, Some(functionalFailed))

--- a/core/recipe-compiler/src/main/scala/com/ing/baker/compiler/package.scala
+++ b/core/recipe-compiler/src/main/scala/com/ing/baker/compiler/package.scala
@@ -75,28 +75,41 @@ package object compiler {
         case _ => Seq.empty
       }.toMap ++ interactionDescriptor.predefinedIngredients
 
-      val (failureStrategy: InteractionFailureStrategy, exhaustedRetryEvent: Option[EventDescriptor]) = {
+      val (failureStrategy: InteractionFailureStrategy, exhaustedRetryEvent: Option[EventDescriptor], functionalRetryEvent: Option[EventDescriptor]) = {
         interactionDescriptor.failureStrategy.getOrElse[common.InteractionFailureStrategy](defaultFailureStrategy) match {
-          case common.InteractionFailureStrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, fireRetryExhaustedEvent) =>
+          case common.InteractionFailureStrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, fireRetryExhaustedEvent, fireFunctionalEvent) =>
             val exhaustedRetryEvent: Option[EventDescriptor] = fireRetryExhaustedEvent match {
               case Some(None)            => Some(EventDescriptor(interactionDescriptor.name + exhaustedEventAppend, Seq.empty))
               case Some(Some(eventName)) => Some(EventDescriptor(eventName, Seq.empty))
               case None                  => None
             }
-            (il.failurestrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, exhaustedRetryEvent), exhaustedRetryEvent)
-          case common.InteractionFailureStrategy.BlockInteraction() => (
-            il.failurestrategy.BlockInteraction, None)
+            val functionalFailedEvent: Option[EventDescriptor] = fireFunctionalEvent match {
+              case Some(None)            => Some(EventDescriptor(interactionDescriptor.name + functionalFailedEventAppend, Seq.empty))
+              case Some(Some(eventName)) => Some(EventDescriptor(eventName, Seq.empty))
+              case None                  => None
+            }
+
+            (il.failurestrategy.RetryWithIncrementalBackoff(initialTimeout, backoffFactor, maximumRetries, maxTimeBetweenRetries, exhaustedRetryEvent, functionalFailedEvent),exhaustedRetryEvent, functionalFailedEvent)
+
+          case common.InteractionFailureStrategy.BlockInteraction() => (il.failurestrategy.BlockInteraction, None, None)
+
           case common.InteractionFailureStrategy.FireEventAfterFailure(eventNameOption) =>
             val eventName = eventNameOption.getOrElse(interactionDescriptor.name + exhaustedEventAppend)
             val exhaustedRetryEvent: EventDescriptor = EventDescriptor(eventName, Seq.empty)
-            (il.failurestrategy.FireEventAfterFailure(exhaustedRetryEvent), Some(exhaustedRetryEvent))
-          case _ => (il.failurestrategy.BlockInteraction, None)
+            (il.failurestrategy.FireEventAfterFailure(exhaustedRetryEvent), Some(exhaustedRetryEvent), None)
+
+          case common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(eventNameOption) =>
+            val eventName = eventNameOption.getOrElse(interactionDescriptor.name + functionalFailedEventAppend)
+            val functionalFailed: EventDescriptor = EventDescriptor(eventName, Seq.empty)
+            (il.failurestrategy.FireFunctionalEventAfterFailure(functionalFailed), None, Some(functionalFailed))
+
+          case _ => (il.failurestrategy.BlockInteraction, None, None)
         }
       }
 
       InteractionTransition(
-        eventsToFire = eventsToFire ++ exhaustedRetryEvent,
-        originalEvents = originalEvents ++ exhaustedRetryEvent,
+        eventsToFire = eventsToFire ++ exhaustedRetryEvent ++ functionalRetryEvent,
+        originalEvents = originalEvents ++ exhaustedRetryEvent ++ functionalRetryEvent,
         requiredIngredients = inputFields.map { case (name, ingredientType) => IngredientDescriptor(name, ingredientType) },
         interactionName = interactionDescriptor.name,
         originalInteractionName = interactionDescriptor.originalName,

--- a/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -42,7 +42,7 @@ class RecipeBuilder(private val name: String) {
     /**
      * The default failure strategy for interactions that don't specify a failure strategy explicitly.
      *
-     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAfterFailure], [fireFunctionalEventAfterFailure] and [blockInteraction].
+     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAndBlock], [fireEventAndResolve] and [blockInteraction].
      * Defaults to [blockInteraction].
      */
     var defaultFailureStrategy: InteractionFailureStrategyBuilder = BlockInteractionBuilder
@@ -184,32 +184,50 @@ class RecipeBuilder(private val name: String) {
         return BlockInteractionBuilder
     }
 
-    /**
-     * Fires an event with a specified [name] on failure.
-     */
+    @Deprecated("Please use fireEventAndBlock or fireEventAndResolve, the fireEventAndBlock is exactly as the old fireEventAfterFailure")
     fun fireEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
-        return FireEventAfterFailureBuilder(name)
+        return FireEventAndBlockBuilder(name)
     }
 
-    /**
-     * Fires an event [T] on failure.
-     */
+    @Deprecated("Please use fireEventAndBlock or fireEventAndResolve, the fireEventAndBlock is exactly as the old fireEventAfterFailure")
     inline fun <reified T> fireEventAfterFailure(): InteractionFailureStrategyBuilder {
-        return FireEventAfterFailureBuilder(T::class.simpleName!!)
+        return FireEventAndBlockBuilder(T::class.simpleName!!)
     }
 
     /**
-     * Fires a functional event with a specified [name] on failure.
+     * After the interaction fails with an exception an event with a specified [name] is thrown and the interaction is blocked.
+     * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+     * @return
      */
-    fun fireFunctionalEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
-        return FireFunctionalEventAfterFailureBuilder(name)
+    fun fireEventAndBlock(name: String): InteractionFailureStrategyBuilder {
+        return FireEventAndBlockBuilder(name)
     }
 
     /**
-     * Fires a functional event [T] on failure.
+     * After the interaction fails with an exception an event [T] is thrown and the interaction is blocked.
+     * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+     * @return
      */
-    inline fun <reified T> fireFunctionalEventAfterFailure(): InteractionFailureStrategyBuilder {
-        return FireFunctionalEventAfterFailureBuilder(T::class.simpleName!!)
+    inline fun <reified T> fireEventAndBlock(): InteractionFailureStrategyBuilder {
+        return FireEventAndBlockBuilder(T::class.simpleName!!)
+    }
+
+    /**
+     * After the interaction fails with an exception an event with a specified [name] is thrown and the interaction is not blocked.
+     * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+     * @return
+     */
+    fun fireEventAndResolve(name: String): InteractionFailureStrategyBuilder {
+        return FireEventAndResolveBuilder(name)
+    }
+
+    /**
+     * After the interaction fails with an exception an event [T] is thrown and the interaction is not blocked.
+     * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+     * @return
+     */
+    inline fun <reified T> fireEventAndResolve(): InteractionFailureStrategyBuilder {
+        return FireEventAndResolveBuilder(T::class.simpleName!!)
     }
 
     internal fun build() = Recipe(
@@ -240,7 +258,7 @@ class InteractionBuilder(private val interactionClass: KClass<out com.ing.baker.
     /**
      * The failure strategy for this interaction.
      *
-     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAfterFailure], and [blockInteraction].
+     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAndBlock] [FireEventAndResolve], and [blockInteraction].
      * Defaults to the failure strategy of the recipe.
      */
     var failureStrategy: InteractionFailureStrategyBuilder? = null
@@ -325,32 +343,50 @@ class InteractionBuilder(private val interactionClass: KClass<out com.ing.baker.
         return BlockInteractionBuilder
     }
 
-    /**
-     * Fires an event with a specified [name] on failure.
-     */
+    @Deprecated("Please use fireEventAndBlockAfterFailure or fireEventAndBlockAfterFailure, the fireEventAndBlockAfterFailure is exactly as the old fireEventAfterFailure")
     fun fireEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
-        return FireEventAfterFailureBuilder(name)
+        return FireEventAndBlockBuilder(name)
     }
 
-    /**
-     * Fires an event [T] on failure.
-     */
+    @Deprecated("Please use fireEventAndBlockAfterFailure or fireEventAndBlockAfterFailure, the fireEventAndBlockAfterFailure is exactly as the old fireEventAfterFailure")
     inline fun <reified T> fireEventAfterFailure(): InteractionFailureStrategyBuilder {
-        return FireEventAfterFailureBuilder(T::class.simpleName!!)
+        return FireEventAndBlockBuilder(T::class.simpleName!!)
     }
 
     /**
-     * Fires an event with a specified [name] on failure.
+     * After the interaction fails with an exception an event with a specified [name] is thrown and the interaction is blocked.
+     * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+     * @return
      */
-    fun fireFunctionalEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
-        return FireFunctionalEventAfterFailureBuilder(name)
+    fun fireEventAndBlock(name: String): InteractionFailureStrategyBuilder {
+        return FireEventAndBlockBuilder(name)
     }
 
     /**
-     * Fires an event [T] on failure.
+     * After the interaction fails with an exception an event [T] is thrown and the interaction is blocked.
+     * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+     * @return
      */
-    inline fun <reified T> fireFunctionalEventAfterFailure(): InteractionFailureStrategyBuilder {
-        return FireFunctionalEventAfterFailureBuilder(T::class.simpleName!!)
+    inline fun <reified T> fireEventAndBlock(): InteractionFailureStrategyBuilder {
+        return FireEventAndBlockBuilder(T::class.simpleName!!)
+    }
+
+    /**
+     * After the interaction fails with an exception an event with a specified [name] is thrown and the interaction is not blocked.
+     * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+     * @return
+     */
+    fun fireEventAndResolve(name: String): InteractionFailureStrategyBuilder {
+        return FireEventAndResolveBuilder(name)
+    }
+
+    /**
+     * After the interaction fails with an exception an event [T] is thrown and the interaction is not blocked.
+     * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+     * @return
+     */
+    inline fun <reified T> fireEventAndResolve(): InteractionFailureStrategyBuilder {
+        return FireEventAndResolveBuilder(T::class.simpleName!!)
     }
 
     @PublishedApi
@@ -546,14 +582,30 @@ object BlockInteractionBuilder : InteractionFailureStrategyBuilder {
         BlockInteraction()
 }
 
+@Deprecated("Please use FireEventAndBlock or FireEventAndResolve, the FireEventAndBlock is exactly as the old FireEvent")
 class FireEventAfterFailureBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
     override fun build(): com.ing.baker.recipe.common.InteractionFailureStrategy =
-        com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAfterFailure(Option.apply(eventName))
+        com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAndBlock(Option.apply(eventName))
 }
 
-class FireFunctionalEventAfterFailureBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
+/**
+ * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+ * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+ * @return
+ */
+class FireEventAndBlockBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
     override fun build(): com.ing.baker.recipe.common.InteractionFailureStrategy =
-        com.ing.baker.recipe.common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(Option.apply(eventName))
+        com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAndBlock(Option.apply(eventName))
+}
+
+/**
+ * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+ * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+ * @return
+ */
+class FireEventAndResolveBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
+    override fun build(): com.ing.baker.recipe.common.InteractionFailureStrategy =
+        com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAndResolve(Option.apply(eventName))
 }
 
 @RecipeDslMarker

--- a/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -42,7 +42,7 @@ class RecipeBuilder(private val name: String) {
     /**
      * The default failure strategy for interactions that don't specify a failure strategy explicitly.
      *
-     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAfterFailure], and [blockInteraction].
+     * Available strategies are: [retryWithIncrementalBackoff], [fireEventAfterFailure], [fireFunctionalEventAfterFailure] and [blockInteraction].
      * Defaults to [blockInteraction].
      */
     var defaultFailureStrategy: InteractionFailureStrategyBuilder = BlockInteractionBuilder
@@ -198,6 +198,20 @@ class RecipeBuilder(private val name: String) {
         return FireEventAfterFailureBuilder(T::class.simpleName!!)
     }
 
+    /**
+     * Fires a functional event with a specified [name] on failure.
+     */
+    fun fireFunctionalEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
+        return FireFunctionalEventAfterFailureBuilder(name)
+    }
+
+    /**
+     * Fires a functional event [T] on failure.
+     */
+    inline fun <reified T> fireFunctionalEventAfterFailure(): InteractionFailureStrategyBuilder {
+        return FireFunctionalEventAfterFailureBuilder(T::class.simpleName!!)
+    }
+
     internal fun build() = Recipe(
         name,
         interactions.toList(),
@@ -323,6 +337,20 @@ class InteractionBuilder(private val interactionClass: KClass<out com.ing.baker.
      */
     inline fun <reified T> fireEventAfterFailure(): InteractionFailureStrategyBuilder {
         return FireEventAfterFailureBuilder(T::class.simpleName!!)
+    }
+
+    /**
+     * Fires an event with a specified [name] on failure.
+     */
+    fun fireFunctionalEventAfterFailure(name: String): InteractionFailureStrategyBuilder {
+        return FireFunctionalEventAfterFailureBuilder(name)
+    }
+
+    /**
+     * Fires an event [T] on failure.
+     */
+    inline fun <reified T> fireFunctionalEventAfterFailure(): InteractionFailureStrategyBuilder {
+        return FireFunctionalEventAfterFailureBuilder(T::class.simpleName!!)
     }
 
     @PublishedApi
@@ -521,6 +549,11 @@ object BlockInteractionBuilder : InteractionFailureStrategyBuilder {
 class FireEventAfterFailureBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
     override fun build(): com.ing.baker.recipe.common.InteractionFailureStrategy =
         com.ing.baker.recipe.common.InteractionFailureStrategy.FireEventAfterFailure(Option.apply(eventName))
+}
+
+class FireFunctionalEventAfterFailureBuilder(private val eventName: String) : InteractionFailureStrategyBuilder {
+    override fun build(): com.ing.baker.recipe.common.InteractionFailureStrategy =
+        com.ing.baker.recipe.common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(Option.apply(eventName))
 }
 
 @RecipeDslMarker

--- a/core/recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
+++ b/core/recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
@@ -45,18 +45,18 @@ class KotlinDslTest {
             }
 
             interaction<Interactions.MakePayment> {
-                failureStrategy = fireEventAfterFailure<Events.OrderPlaced>()
+                failureStrategy = fireEventAndBlock<Events.OrderPlaced>()
             }
             interaction<Interactions.ReserveItems> {
-                failureStrategy = fireEventAfterFailure("OrderPlaced")
+                failureStrategy = fireEventAndBlock("OrderPlaced")
             }
             interaction<Interactions.MakePayment> {
                 name = "MakePayment2"
-                failureStrategy = fireFunctionalEventAfterFailure<Events.OrderPlaced>()
+                failureStrategy = fireEventAndResolve<Events.OrderPlaced>()
             }
             interaction<Interactions.ReserveItems> {
                 name = "ReserveItems2"
-                failureStrategy = fireFunctionalEventAfterFailure("OrderPlaced")
+                failureStrategy = fireEventAndResolve("OrderPlaced")
             }
             interaction<Interactions.ShipItems> {
                 failureStrategy = retryWithIncrementalBackoff {
@@ -118,7 +118,7 @@ class KotlinDslTest {
 
             with(failureStrategy().get()) {
                 when (this) {
-                    is InteractionFailureStrategy.FireEventAfterFailure -> {
+                    is InteractionFailureStrategy.FireEventAndBlock -> {
                         assertEquals("OrderPlaced", eventName().get())
                     }
 
@@ -137,7 +137,7 @@ class KotlinDslTest {
 
             with(failureStrategy().get()) {
                 when (this) {
-                    is InteractionFailureStrategy.FireEventAfterFailure -> {
+                    is InteractionFailureStrategy.FireEventAndBlock -> {
                         assertEquals("OrderPlaced", eventName().get())
                     }
 
@@ -157,7 +157,7 @@ class KotlinDslTest {
 
             with(failureStrategy().get()) {
                 when (this) {
-                    is InteractionFailureStrategy.FireFunctionalEventAfterFailure -> {
+                    is InteractionFailureStrategy.FireEventAndResolve -> {
                         assertEquals("OrderPlaced", eventName().get())
                     }
 
@@ -176,7 +176,7 @@ class KotlinDslTest {
 
             with(failureStrategy().get()) {
                 when (this) {
-                    is InteractionFailureStrategy.FireFunctionalEventAfterFailure -> {
+                    is InteractionFailureStrategy.FireEventAndResolve -> {
                         assertEquals("OrderPlaced", eventName().get())
                     }
                     else -> error("Classname did not match ")

--- a/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
+++ b/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
@@ -9,9 +9,26 @@ object InteractionFailureStrategy {
 
   case class BlockInteraction() extends InteractionFailureStrategy
 
+  /**
+   * @deprecated
+   * Please use FireEventAndBlock or FireEventAndResolve, the FireEventAndBlock is exactly as the old FireEvent
+   */
+  @Deprecated()
   case class FireEventAfterFailure(eventName: Option[String] = None) extends InteractionFailureStrategy
 
-  case class FireFunctionalEventAfterFailure(eventName: Option[String] = None) extends InteractionFailureStrategy
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+   * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+   * @return
+   */
+  case class FireEventAndBlock(eventName: Option[String] = None) extends InteractionFailureStrategy
+
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is not blocked.
+   * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+   * @return
+   */
+  case class FireEventAndResolve(eventName: Option[String] = None) extends InteractionFailureStrategy
 
   case class RetryWithIncrementalBackoff private(initialDelay: Duration,
                                                  backoffFactor: Double = 2,

--- a/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
+++ b/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/common/InteractionFailureStrategy.scala
@@ -11,11 +11,14 @@ object InteractionFailureStrategy {
 
   case class FireEventAfterFailure(eventName: Option[String] = None) extends InteractionFailureStrategy
 
+  case class FireFunctionalEventAfterFailure(eventName: Option[String] = None) extends InteractionFailureStrategy
+
   case class RetryWithIncrementalBackoff private(initialDelay: Duration,
                                                  backoffFactor: Double = 2,
                                                  maximumRetries: Int,
                                                  maxTimeBetweenRetries: Option[Duration] = None,
-                                                 fireRetryExhaustedEvent: Option[Option[String]] = None) extends InteractionFailureStrategy {
+                                                 fireRetryExhaustedEvent: Option[Option[String]] = None,
+                                                 fireFunctionalEvent: Option[Option[String]] = None) extends InteractionFailureStrategy {
     require(backoffFactor >= 1.0, "backoff factor must be greater or equal to 1.0")
     require(maximumRetries >= 1, "maximum retries must be greater or equal to 1")
   }

--- a/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
+++ b/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
@@ -48,10 +48,19 @@ object InteractionFailureStrategy {
 
   def FireEvent(): common.InteractionFailureStrategy.FireEventAfterFailure = common.InteractionFailureStrategy.FireEventAfterFailure(None)
 
-  def FireEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAfterFailure = FireEvent(eventClass.getSimpleName)
+  def FireEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAfterFailure =
+    FireEvent(eventClass.getSimpleName)
 
   def FireEvent(eventName: String): common.InteractionFailureStrategy.FireEventAfterFailure =
     common.InteractionFailureStrategy.FireEventAfterFailure(Some(eventName))
+
+
+  def FireFunctionalEvent(): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure = common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(None)
+
+  def FireFunctionalEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure = FireFunctionalEvent(eventClass.getSimpleName)
+
+  def FireFunctionalEvent(eventName: String): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure =
+    common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(Some(eventName))
 
   def BlockInteraction(): BlockInteraction =
     common.InteractionFailureStrategy.BlockInteraction()

--- a/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
+++ b/core/recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/InteractionFailureStrategy.scala
@@ -46,21 +46,76 @@ object InteractionFailureStrategy {
     }
   }
 
+  /**
+   * @deprecated
+   * Please use FireEventAndBlock or FireEventAndResolve, the FireEventAndBlock is exactly as the old FireEvent
+   */
+  @Deprecated()
   def FireEvent(): common.InteractionFailureStrategy.FireEventAfterFailure = common.InteractionFailureStrategy.FireEventAfterFailure(None)
 
+  /**
+   * @deprecated
+   * Please use FireEventAndBlock or FireEventAndResolve, the FireEventAndBlock is exactly as the old FireEvent
+   */
+  @Deprecated()
   def FireEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAfterFailure =
     FireEvent(eventClass.getSimpleName)
 
+  /**
+   * @deprecated
+   * Please use FireEventAndBlock or FireEventAndResolve, the FireEventAndBlock is exactly as the old FireEvent
+   */
+  @Deprecated()
   def FireEvent(eventName: String): common.InteractionFailureStrategy.FireEventAfterFailure =
     common.InteractionFailureStrategy.FireEventAfterFailure(Some(eventName))
 
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+   * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+   * @return
+   */
+  def FireEventAndBlock(): common.InteractionFailureStrategy.FireEventAndBlock = common.InteractionFailureStrategy.FireEventAndBlock(None)
 
-  def FireFunctionalEvent(): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure = common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(None)
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+   * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+   * @return
+   */
+  def FireEventAndBlock(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAndBlock =
+    FireEventAndBlock(eventClass.getSimpleName)
 
-  def FireFunctionalEvent(eventClass: Class[_]): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure = FireFunctionalEvent(eventClass.getSimpleName)
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is blocked.
+   * Blocked interactions cannot execute again until retryInteraction or resolveInteraction is called on Baker.
+   * @return
+   */
+  def FireEventAndBlock(eventName: String): common.InteractionFailureStrategy.FireEventAndBlock =
+    common.InteractionFailureStrategy.FireEventAndBlock(Some(eventName))
 
-  def FireFunctionalEvent(eventName: String): common.InteractionFailureStrategy.FireFunctionalEventAfterFailure =
-    common.InteractionFailureStrategy.FireFunctionalEventAfterFailure(Some(eventName))
+
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is not blocked.
+   * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+   * @return
+   */
+  def FireEventAndResolve(): common.InteractionFailureStrategy.FireEventAndResolve =
+    common.InteractionFailureStrategy.FireEventAndResolve(None)
+
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is not blocked.
+   * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+   * @return
+   */
+  def FireEventAndResolve(eventClass: Class[_]): common.InteractionFailureStrategy.FireEventAndResolve =
+    FireEventAndResolve(eventClass.getSimpleName)
+
+  /**
+   * After the interaction fails with an exception an event is thrown and the interaction is not blocked.
+   * This means the interaction can be executed again if the preconditions are met but retryInteraction or resolveInteraction cannot be done.
+   * @return
+   */
+  def FireEventAndResolve(eventName: String): common.InteractionFailureStrategy.FireEventAndResolve =
+    common.InteractionFailureStrategy.FireEventAndResolve(Some(eventName))
 
   def BlockInteraction(): BlockInteraction =
     common.InteractionFailureStrategy.BlockInteraction()

--- a/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeFireEvent.kt
+++ b/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeFireEvent.kt
@@ -6,6 +6,6 @@ import com.ing.baker.recipe.kotlindsl.recipe
 @ExperimentalDsl
 object RecipeFireEvent {
     val recipe = recipe("example") {
-        defaultFailureStrategy = fireEventAfterFailure("MyEvent")
+        defaultFailureStrategy = fireEventAndBlock("MyEvent")
     }
 }

--- a/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeWithDefaultFailureStrategy.kt
+++ b/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeWithDefaultFailureStrategy.kt
@@ -7,6 +7,6 @@ import examples.kotlin.interactions.ShipOrder
 @ExperimentalDsl
 object RecipeWithDefaultFailureStrategy {
     val recipe = recipe("example") {
-        defaultFailureStrategy = fireEventAfterFailure("recipeFailed")
+        defaultFailureStrategy = fireEventAndBlock("recipeFailed")
     }
 }

--- a/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeWithFailureStrategy.kt
+++ b/examples/docs-code-snippets/src/main/kotlin/examples/kotlin/recipes/RecipeWithFailureStrategy.kt
@@ -8,7 +8,7 @@ import examples.kotlin.interactions.ShipOrder
 object RecipeWithFailureStrategy {
     val recipe = recipe("example") {
         interaction<ShipOrder> {
-            failureStrategy = fireEventAfterFailure("shippingFailed")
+            failureStrategy = fireEventAndBlock("shippingFailed")
         }
     }
 }

--- a/examples/docs-code-snippets/src/main/scala/examples/scala/recipes/RecipeWithDefaultFailureStrategy.scala
+++ b/examples/docs-code-snippets/src/main/scala/examples/scala/recipes/RecipeWithDefaultFailureStrategy.scala
@@ -6,6 +6,6 @@ import com.ing.baker.recipe.scaladsl.Recipe
 object RecipeWithDefaultFailureStrategy {
   val recipe: Recipe = Recipe("example")
     .withDefaultFailureStrategy(
-      InteractionFailureStrategy.FireEventAfterFailure(Some("recipeFailed"))
+      InteractionFailureStrategy.FireEventAndBlock(Some("recipeFailed"))
     )
 }

--- a/examples/docs-code-snippets/src/main/scala/examples/scala/recipes/RecipeWithFailureStrategy.scala
+++ b/examples/docs-code-snippets/src/main/scala/examples/scala/recipes/RecipeWithFailureStrategy.scala
@@ -9,7 +9,7 @@ object RecipeWithFailureStrategy {
     .withInteraction(
       ShipOrder.interaction
         .withFailureStrategy(
-          InteractionFailureStrategy.FireEventAfterFailure(Some("shippingFailed"))
+          InteractionFailureStrategy.FireEventAndBlock(Some("shippingFailed"))
         )
     )
 }


### PR DESCRIPTION
 First setup of the FireFunctionalEventAfterFailure as alternative of the FireEventAfterFailure. This retry strategy does not block the interaction so it can be re-execute by providing the preconditions again. You cannot retry the interaction with Baker.RetryInteraction.