### PR TITLE
Made the Java & Kotlin DSL support the name of the interaction from the name field

### DIFF
--- a/core/baker-recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
+++ b/core/baker-recipe-dsl-kotlin/src/main/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDsl.kt
@@ -245,10 +245,22 @@ class RecipeBuilder(private val name: String) {
 
 @RecipeDslMarker
 class InteractionBuilder(private val interactionClass: KClass<out com.ing.baker.recipe.javadsl.Interaction>) {
+
+    private fun getNameFieldName(): Option<String> {
+        val field = runCatching { interactionClass.java.getDeclaredField("name") }.getOrNull()
+
+        return if (field != null && field.type == String::class.java) {
+            field.isAccessible = true
+            Option.apply(field.get(null) as? String)
+        } else {
+            Option.empty()
+        }
+    }
+
     /**
      * The name of the interaction. Defaults to the name of the interaction class.
      */
-    var name: String = interactionClass.simpleName!! // Not null assertion is okay, will never be an anonymous class.
+    var name: String = getNameFieldName().getOrElse { interactionClass.simpleName!! } // Not null assertion is okay, will never be an anonymous class.
 
     /**
      * The maximum number of times this interaction can be invoked.

--- a/core/baker-recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
+++ b/core/baker-recipe-dsl-kotlin/src/test/kotlin/com/ing/baker/recipe/kotlindsl/KotlinDslTest.kt
@@ -102,6 +102,7 @@ class KotlinDslTest {
                     "reservedItems" to "krakaka"
                 }
             }
+            interaction<Interactions.InteractionWithNameField> {}
         }
 
         assertEquals("Name", recipe.name())
@@ -255,6 +256,10 @@ class KotlinDslTest {
             assertEquals("krakaka", overriddenIngredientNames().get("reservedItems").get())
 
             assertTrue(failureStrategy().isEmpty)
+        }
+
+        with(recipe.interactions().toList().apply(6)) {
+            assertEquals("nameField", name())
         }
 
         with(recipe.sensoryEvents()) {
@@ -600,6 +605,7 @@ class KotlinDslTest {
     object Interactions {
 
         interface MakePayment : Interaction {
+
             sealed interface MakePaymentOutcome
             object PaymentSuccessful : MakePaymentOutcome
             object PaymentFailed : MakePaymentOutcome
@@ -609,6 +615,15 @@ class KotlinDslTest {
                 paymentInformation: Ingredients.PaymentInformation
             ): MakePaymentOutcome
         }
+
+        interface InteractionWithNameField : Interaction {
+            companion object {
+                const val name = "nameField"
+            }
+            object InteractionWithNameFieldDone
+            fun apply(): InteractionWithNameFieldDone
+        }
+
 
         interface ShipItems : Interaction {
             object ShippingConfirmed

--- a/core/baker-recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/package.scala
+++ b/core/baker-recipe-dsl/src/main/scala/com/ing/baker/recipe/javadsl/package.scala
@@ -2,11 +2,11 @@ package com.ing.baker.recipe
 
 import java.lang.reflect.Method
 import java.util.concurrent.CompletableFuture
-
 import com.ing.baker.recipe.javadsl.ReflectionHelpers._
 import com.ing.baker.types.{Converters, Type}
 
 import scala.reflect.ClassTag
+import scala.util.Try
 
 package object javadsl {
 
@@ -30,7 +30,19 @@ package object javadsl {
 
   def interactionClassToCommonInteraction(interactionClass: Class[_], newName: Option[String]): InteractionDescriptor = {
 
-    val name: String = interactionClass.getSimpleName
+    def getNameFieldName: Option[String] = {
+      Try {
+        interactionClass.getDeclaredField("name")
+      }.toOption match {
+        // In case a specific 'name' field was found, this is used
+        case Some(field) if field.getType == classOf[String] =>
+          field.setAccessible(true)
+          Some(field.get(interactionClass).asInstanceOf[String])
+        case _ => None
+      }
+    }
+1
+    val name: String = getNameFieldName.getOrElse(interactionClass.getSimpleName)
 
     val method: Method = interactionClass.getDeclaredMethods
       .find(_.getName == interactionMethodName)

--- a/core/baker-recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/RecipeTest.java
+++ b/core/baker-recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/RecipeTest.java
@@ -3,6 +3,7 @@ package com.ing.baker.recipe.javadsl;
 import com.ing.baker.recipe.javadsl.events.SensoryEventWithIngredient;
 import com.ing.baker.recipe.javadsl.events.SensoryEventWithoutIngredient;
 import com.ing.baker.recipe.javadsl.interactions.FiresTwoEventInteraction;
+import com.ing.baker.recipe.javadsl.interactions.InteractionWithNameField;
 import com.ing.baker.recipe.javadsl.interactions.SimpleInteraction;
 import com.ing.baker.recipe.javadsl.interactions.RequiresRecipeInstanceIdStringInteraction;
 import org.junit.Rule;
@@ -161,5 +162,12 @@ public class RecipeTest {
                 .withSubRecipe(subRecipe);
         assertEquals(recipe.getEvents().size(), 0);
         assertEquals(recipe.getSubRecipes().size(), 1);
+    }
+
+    @Test
+    public void shouldSetupRecipeWithInteractionNameFromField() {
+        Recipe recipe = new Recipe("OneInteractionRecipe")
+                .withInteraction(of(InteractionWithNameField.class));
+        assertEquals(recipe.getInteractions().getFirst().name(), "NameField");
     }
 }

--- a/core/baker-recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/interactions/InteractionWithNameField.java
+++ b/core/baker-recipe-dsl/src/test/java/com/ing/baker/recipe/javadsl/interactions/InteractionWithNameField.java
@@ -1,0 +1,13 @@
+package com.ing.baker.recipe.javadsl.interactions;
+
+import com.ing.baker.recipe.annotations.FiresEvent;
+
+public interface InteractionWithNameField {
+
+    String name = "NameField";
+
+    class InteractionWithNameFieldEvent { }
+
+    @FiresEvent(oneOf = { InteractionWithNameFieldEvent.class })
+    InteractionWithNameFieldEvent apply();
+}


### PR DESCRIPTION
Made the Java & Kotlin DSL support the name of the interaction from the name field. This field is already supported on the interaction execution level.